### PR TITLE
Change sprintf call with array to vsprintf

### DIFF
--- a/src/Common/Internal/ConnectionStringParser.php
+++ b/src/Common/Internal/ConnectionStringParser.php
@@ -172,7 +172,7 @@ class ConnectionStringParser
         $arguments = func_get_args();
         
         // Remove first argument (position)
-        unset($arguments[0]);
+        unset($arguments[0], $arguments[1]);
         
         // Create a short error message.
         $errorString = vsprintf($errorString, $arguments);

--- a/src/Common/Internal/ConnectionStringParser.php
+++ b/src/Common/Internal/ConnectionStringParser.php
@@ -175,7 +175,7 @@ class ConnectionStringParser
         unset($arguments[0]);
         
         // Create a short error message.
-        $errorString = sprintf($errorString, $arguments);
+        $errorString = vsprintf($errorString, $arguments);
         
         // Add position.
         $errorString = sprintf(


### PR DESCRIPTION
sprintf accepts a variable number of arguments, while an array needs to be passed here instead.

You can test this error like this:

```php
use MicrosoftAzure\Storage\Common\Internal\StorageServiceSettings;

StorageServiceSettings::createFromConnectionString('invalid');
```