### PR TITLE
Fix: ConnectionStringParser::_createException incorrectly calls sprintf

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+2016.09 - version 0.10.3
+
+ALL
+* Fix error string when an error occurs while parsing a connection string and is passed to _createException in ConnectionStringParser.
+
 2016.08 - version 0.10.2
 
 ALL

--- a/src/Common/Internal/ConnectionStringParser.php
+++ b/src/Common/Internal/ConnectionStringParser.php
@@ -171,11 +171,11 @@ class ConnectionStringParser
     {
         $arguments = func_get_args();
         
-        // Remove first argument (position)
-        unset($arguments[0]);
+        // Remove first and second arguments (position and error string)
+        unset($arguments[0], $arguments[1]);
         
         // Create a short error message.
-        $errorString = sprintf($errorString, $arguments);
+        $errorString = vsprintf($errorString, $arguments);
         
         // Add position.
         $errorString = sprintf(


### PR DESCRIPTION
`sprintf` accepts a variable number of arguments, while an array needs to be passed here instead. An alternative is to call `vsprintf` instead.

Fixes #25