### PR TITLE
Add support for storage account shared access signature generation

### DIFF
--- a/src/Common/Internal/Authentication/SharedAccessSignatureHelper.php
+++ b/src/Common/Internal/Authentication/SharedAccessSignatureHelper.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * LICENSE: The MIT License (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/azure/azure-storage-php/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * PHP version 5
+ *
+ * @category  Microsoft
+ * @package   MicrosoftAzure\Storage\Common\Internal\Authentication
+ * @author    Azure Storage PHP SDK <dmsh@microsoft.com>
+ * @copyright Microsoft Corporation
+ * @license   https://github.com/azure/azure-storage-php/LICENSE
+ * @link      https://github.com/azure/azure-storage-php
+ */
+
+namespace MicrosoftAzure\Storage\Common\Internal\Authentication;
+
+
+use MicrosoftAzure\Storage\Common\Internal\Resources;
+use MicrosoftAzure\Storage\Common\Internal\Validate;
+
+/**
+ * Provides methods to generate Azure Storage Shared Access Signature
+ *
+ * @category  Microsoft
+ * @package   MicrosoftAzure\Storage\Common\Internal\Authentication
+ * @author    Azure Storage PHP SDK <dmsh@microsoft.com>
+ * @copyright 2017 Microsoft Corporation
+ * @license   https://github.com/azure/azure-storage-php/LICENSE
+ * @link      https://github.com/azure/azure-storage-php
+ */
+class SharedAccessSignatureHelper {
+
+    protected $accountName;
+    protected $accountKey;
+
+
+    /**
+     * Constructor.
+     *
+     * @param string $accountName the name of the storage account.
+     * @param string $accountKey the shared key of the storage account
+     *
+     * @return
+     * MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper
+     */
+    public function __construct($accountName, $accountKey)
+    {
+        Validate::isString($accountName, 'accountName');
+        Validate::notNullOrEmpty($accountName, 'accountName');
+
+        Validate::isString($accountKey, 'accountKey');
+        Validate::notNullOrEmpty($accountKey, 'accountKey');
+
+        $this->accountName = urldecode($accountName);
+        $this->accountKey = $accountKey;
+    }
+
+    /**
+     * Generates a shared access signature at the account level.
+     *
+     * @param string $signedVersion         Specifies the signed version to use.
+     * @param string $signedPermissions     Specifies the signed permissions for the account SAS.
+     * @param string $signedService         Specifies the signed services accessible with the account SAS.
+     * @param string $signedResourceType    Specifies the signed resource types that are accessible with the account SAS.
+     * @param string $signedExpiracy        The time at which the shared access signature becomes invalid, in an ISO 8601 format.
+     * @param string $signedStart           The time at which the SAS becomes valid, in an ISO 8601 format.
+     * @param string $signedIP              Specifies an IP address or a range of IP addresses from which to accept requests.
+     * @param string $signedProtocol        Specifies the protocol permitted for a request made with the account SAS.
+     *
+     * @see Constructing an account SAS at
+     *      https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/constructing-an-account-sas
+     *
+     * @return string
+     */
+    public function generateAccountSharedAccessSignatureToken(
+        $signedVersion,
+        $signedPermissions,
+        $signedService,
+        $signedResourceType,
+        $signedExpiracy,
+        $signedStart = "",
+        $signedIP = "",
+        $signedProtocol = ""
+    ) {
+        // check that version is valid
+        Validate::isString($signedVersion, 'signedVersion');
+        Validate::notNullOrEmpty($signedVersion, 'signedVersion');
+        Validate::isDateString($signedVersion, 'signedVersion');
+
+        // validate and sanitize signed service
+        $signedService = $this->validateAndSanitizeSignedService($signedService);
+
+        // validate and sanitize signed resource type
+        $signedResourceType = $this->validateAndSanitizeSignedResourceType($signedResourceType);
+        
+        // validate and sanitize signed permissions
+        $signedPermissions = $this->validateAndSanitizeSignedPermissions($signedPermissions);
+
+        // check that expiracy is valid
+        Validate::isString($signedExpiracy, 'signedExpiracy');
+        Validate::notNullOrEmpty($signedExpiracy, 'signedExpiracy');
+        Validate::isDateString($signedExpiracy, 'signedExpiracy');
+
+        // check that signed start is valid
+        Validate::isString($signedStart, 'signedStart');
+        if(strlen($signedStart) > 0)
+        {
+            Validate::isDateString($signedStart, 'signedStart');
+        }
+
+        // check that signed IP is valid
+        Validate::isString($signedIP, 'signedIP');
+
+        // validate and sanitize signed protocol
+        $signedProtocol = $this->validateAndSanitizeSignedProtocol($signedProtocol);
+
+        // construct an array with the parameters to generate the shared access signature at the account level
+        $parameters = array();
+        $parameters[] = $this->accountName;
+        $parameters[] = urldecode($signedPermissions);
+        $parameters[] = urldecode($signedService);
+        $parameters[] = urldecode($signedResourceType);
+        $parameters[] = urldecode($signedStart);
+        $parameters[] = urldecode($signedExpiracy);
+        $parameters[] = urldecode($signedIP);
+        $parameters[] = urldecode($signedProtocol);
+        $parameters[] = urldecode($signedVersion);
+
+        // implode the parameters into a string
+        $stringToSign = utf8_encode(implode("\n", $parameters)."\n");
+
+        // decode the account key from base64
+        $decodedAccountKey = base64_decode($this->accountKey);
+        
+        // create the signature with hmac sha256
+        $signature = hash_hmac("sha256", $stringToSign, $decodedAccountKey, true);
+
+        // encode the signature as base64
+        $base64Signature = base64_encode($signature);
+
+        // return the signature
+        return $base64Signature;
+    }
+
+    /**
+     * Validates and sanitizes the signed service parameter
+     *
+     * @param string $signedService         Specifies the signed services accessible with the account SAS.
+     *
+     * @return string
+     */
+    private function validateAndSanitizeSignedService($signedService) {
+        // validate signed service is not null or empty
+        Validate::isString($signedService, 'signedService');
+        Validate::notNullOrEmpty($signedService, 'signedService');
+
+        // sanitize signed service
+        $sanitizedSignedService = $this->removeDuplicateCharacters(strtolower($signedService));
+        
+        // The signed service should only be a combination of the letters b(lob) q(ueue) t(able) or f(ile)
+        $signedServiceIsValid = preg_match("/^[bqtf]*$/", $sanitizedSignedService);
+        if(!$signedServiceIsValid) {
+            throw new \InvalidArgumentException(Resources::SIGNED_SERVICE_INVALID_VALIDATION_MSG);
+        }
+
+        return $sanitizedSignedService;
+    }
+
+    /**
+     * Validates and sanitizes the signed resource type parameter
+     *
+     * @param string $signedResourceType    Specifies the signed resource types that are accessible with the account SAS.
+     *
+     * @return string
+     */
+    private function validateAndSanitizeSignedResourceType($signedResourceType) {
+        // validate signed resource type is not null or empty
+        Validate::isString($signedResourceType, 'signedResourceType');
+        Validate::notNullOrEmpty($signedResourceType, 'signedResourceType');
+
+        // sanitize signed resource type
+        $sanitizedSignedResourceType = $this->removeDuplicateCharacters(strtolower($signedResourceType));
+        
+        // The signed resource type should only be a combination of the letters s(ervice) c(container) or o(bject)
+        $signedResourceTypeIsValid = preg_match("/^[sco]*$/", $sanitizedSignedResourceType);
+        if(!$signedResourceTypeIsValid) {
+            throw new \InvalidArgumentException(Resources::SIGNED_RESOURCE_TYPE_INVALID_VALIDATION_MSG);
+        }
+
+        return $sanitizedSignedResourceType;
+    }
+
+    /**
+     * Validates and sanitizes the signed permissions parameter
+     *
+     * @param string $signedPermissions     Specifies the signed permissions for the account SAS.
+
+     * @return string
+     */
+    private function validateAndSanitizeSignedPermissions($signedPermissions) {
+        // validate signed permissions are not null or empty
+        Validate::isString($signedPermissions, 'signedPermissions');
+        Validate::notNullOrEmpty($signedPermissions, 'signedPermissions');
+
+        // sanitized signed permissions, service and resource type
+        $sanitizedSignedPermissions = $this->removeDuplicateCharacters(strtolower($signedPermissions));
+
+        $validPermissions = ['r', 'w', 'd', 'l', 'a', 'c', 'u', 'p'];
+        $result = '';
+        foreach ($validPermissions as $validPermission) {
+            if (strpos($sanitizedSignedPermissions, $validPermission) !== false) {
+                //append the valid permission to result.
+                $result .= $validPermission;
+                //remove all the character that represents the permission.
+                $sanitizedSignedPermissions = str_replace(
+                    $validPermission,
+                    '',
+                    $sanitizedSignedPermissions
+                );
+            }
+        }
+
+        if(strlen($result) == 0) {
+            throw new \InvalidArgumentException(Resources::SIGNED_PERMISSIONS_INVALID_VALIDATION_MSG);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Validates and sanitizes the signed protocol parameter
+     *
+     * @param string $signedProtocol        Specifies the signed protocol for the account SAS.
+
+     * @return string
+     */
+    private function validateAndSanitizeSignedProtocol($signedProtocol) {
+        Validate::isString($signedProtocol, 'signedProtocol');
+        // sanitize string
+        $sanitizedSignedProtocol = strtolower($signedProtocol);
+        if(strlen($sanitizedSignedProtocol) > 0) {
+            if(strcmp($sanitizedSignedProtocol,"https") != 0 && strcmp($sanitizedSignedProtocol, "https,http") != 0) {
+                throw new \InvalidArgumentException(Resources::SIGNED_PROTOCOL_INVALID_VALIDATION_MSG);
+            }
+        }
+
+        return $sanitizedSignedProtocol;
+    }
+
+    /**
+     * Checks if a string contains an other string
+     *
+     * @param string $input        The input to test.
+     * @param string $toFind       The string to find in the input.
+
+     * @return bool
+     */
+    private function strcontains($input, $toFind) {
+        return strpos($input, $toFind) !== false;
+    }
+
+    /**
+     * Removes duplicate characters from a string
+     *
+     * @param string $input        The input string.
+
+     * @return string
+     */
+    private function removeDuplicateCharacters($input) {
+        $inputAsArray = str_split($input);
+        $deduplicated = array_unique($inputAsArray);
+        $output = implode("", $deduplicated);
+        return $output;
+    }
+}

--- a/src/Common/Internal/Resources.php
+++ b/src/Common/Internal/Resources.php
@@ -120,6 +120,10 @@ class Resources
     const ERROR_BLOB_NOT_EXIST = 'The specified blob does not exist';
     const INVALID_PARAM_GENERAL = 'The provided parameter \'%s\' is invalid';
     const INVALID_NEGATIVE_PARAM = 'The provided parameter \'%s\' should be positive number.';
+    const SIGNED_SERVICE_INVALID_VALIDATION_MSG = 'The signed service should only be a combination of the letters b(lob) q(ueue) t(able) or f(ile).';
+    const SIGNED_RESOURCE_TYPE_INVALID_VALIDATION_MSG = 'The signed resource type should only be a combination of the letters s(ervice) c(container) or o(bject).';
+    const SIGNED_PERMISSIONS_INVALID_VALIDATION_MSG = 'The signed permissions should only be a combination of the letters r, w, d, l, a, c, u, p.';
+    const SIGNED_PROTOCOL_INVALID_VALIDATION_MSG = 'The signed protocol is invalid: possible values are https or https,http.';
 
     // HTTP Headers
     const X_MS_HEADER_PREFIX                 = 'x-ms-';

--- a/tests/unit/Common/Internal/Authentication/SharedAccessSignatureHelperTest.php
+++ b/tests/unit/Common/Internal/Authentication/SharedAccessSignatureHelperTest.php
@@ -1,0 +1,359 @@
+<?php
+
+/**
+ * LICENSE: The MIT License (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/azure/azure-storage-php/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * PHP version 5
+ *
+ * @category  Microsoft
+ * @package   MicrosoftAzure\Storage\Tests\Unit\Common
+ * @author    Azure Storage PHP SDK <dmsh@microsoft.com>
+ * @copyright 2017 Microsoft Corporation
+ * @license   https://github.com/azure/azure-storage-php/LICENSE
+ * @link      https://github.com/azure/azure-storage-php
+ */
+
+namespace MicrosoftAzure\Storage\Tests\unit\Common\Internal\Authentication;
+
+use MicrosoftAzure\Storage\Common\ServiceException;
+use MicrosoftAzure\Storage\Tests\framework\TestResources;
+use MicrosoftAzure\Storage\Tests\Framework\ReflectionTestBase;
+use MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper;
+
+/**
+* Unit tests for class SharedAccessSignatureHelper
+*
+* @category  Microsoft
+* @package   MicrosoftAzure\Storage\Tests\Unit\Common
+* @author    Azure Storage PHP SDK <dmsh@microsoft.com>
+* @copyright 2017 Microsoft Corporation
+* @license   https://github.com/azure/azure-storage-php/LICENSE
+* @link      https://github.com/azure/azure-storage-php
+*/
+class SharedAccessSignatureHelperTest extends ReflectionTestBase
+{
+    /**
+    * @covers MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper::__construct
+    */
+    public function testConstruct()
+    {
+        // Setup
+        $accountName = TestResources::ACCOUNT_NAME;
+        $accountKey = TestResources::KEY4;
+
+        // Test
+        $sasHelper = new SharedAccessSignatureHelper($accountName, $accountKey);
+
+        // Assert
+        $this->assertNotNull($sasHelper);
+
+        return $sasHelper;
+    }
+
+    /**
+     * @covers MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper::validateAndSanitizeSignedService
+     */
+    public function testValidateAndSanitizeSignedService()
+    {
+        // Setup
+        $sasHelper = $this->testConstruct();
+        $validateAndSanitizeSignedService = self::getMethod('validateAndSanitizeSignedService', $sasHelper);
+
+        $authorizedSignedService = array();
+        $authorizedSignedService[] = "BqtF";
+        $authorizedSignedService[] = "bQtF";
+        $authorizedSignedService[] = "fqTb";
+        $authorizedSignedService[] = "ffqq";
+        $authorizedSignedService[] = "BbbB";
+        
+        $expected = array();
+        $expected[] = "bqtf";
+        $expected[] = "bqtf";
+        $expected[] = "fqtb";
+        $expected[] = "fq";
+        $expected[] = "b";
+        
+        for ($i = 0; $i < count($authorizedSignedService); $i++) {
+            // Test
+            $actual = $validateAndSanitizeSignedService->invokeArgs($sasHelper, array($authorizedSignedService[$i]));
+
+            // Assert
+            $this->assertEquals($expected[$i], $actual);
+        }
+    }
+
+    /**
+     * @covers MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper::validateAndSanitizeSignedService
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The signed service should only be a combination of the letters b(lob) q(ueue) t(able) or f(ile).
+     */
+    public function testValidateAndSanitizeSignedServiceThrowsException()
+    {
+        // Setup
+        $sasHelper = $this->testConstruct();
+        $validateAndSanitizeSignedService = self::getMethod('validateAndSanitizeSignedService', $sasHelper);
+        $unauthorizedSignedService = "BqTfG";
+
+        // Test: should throw an InvalidArgumentException
+        $validateAndSanitizeSignedService->invokeArgs($sasHelper, array($unauthorizedSignedService));
+    }
+
+    /**
+     * @covers MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper::validateAndSanitizeSignedResourceType
+     */
+    public function testValidateAndSanitizeSignedResourceType()
+    {
+        // Setup
+        $sasHelper = $this->testConstruct();
+        $validateAndSanitizeSignedResourceType = self::getMethod('validateAndSanitizeSignedResourceType', $sasHelper);
+
+        $authorizedSignedResourceType = array();
+        $authorizedSignedResourceType[] = "sCo";
+        $authorizedSignedResourceType[] = "Ocs";
+        $authorizedSignedResourceType[] = "OOsCc";
+        $authorizedSignedResourceType[] = "OOOoo";
+        
+        $expected = array();
+        $expected[] = "sco";
+        $expected[] = "ocs";
+        $expected[] = "osc";
+        $expected[] = "o";
+        
+        for ($i = 0; $i < count($authorizedSignedResourceType); $i++) {
+            // Test
+            $actual = $validateAndSanitizeSignedResourceType->invokeArgs($sasHelper, array($authorizedSignedResourceType[$i]));
+
+            // Assert
+            $this->assertEquals($expected[$i], $actual);
+        }
+    }
+
+    /**
+     * @covers MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper::validateAndSanitizeSignedResourceType
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The signed resource type should only be a combination of the letters s(ervice) c(container) or o(bject).
+     */
+    public function testValidateAndSanitizeSignedResourceTypeThrowsException()
+    {
+        // Setup
+        $sasHelper = $this->testConstruct();
+        $validateAndSanitizeSignedResourceType = self::getMethod('validateAndSanitizeSignedResourceType', $sasHelper);
+
+        $unauthorizedSignedResourceType = "oscB";
+
+        // Test: should throw an InvalidArgumentException
+        $validateAndSanitizeSignedResourceType->invokeArgs($sasHelper, array($unauthorizedSignedResourceType));
+    }
+
+    /**
+     * @covers MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper::validateAndSanitizeSignedProtocol
+     */
+    public function testValidateAndSanitizeSignedProtocol()
+    {
+        // Setup
+        $sasHelper = $this->testConstruct();
+        $validateAndSanitizeSignedProtocol = self::getMethod('validateAndSanitizeSignedProtocol', $sasHelper);
+
+        $authorizedSignedProtocol = array();
+        $authorizedSignedProtocol[] = "hTTpS";
+        $authorizedSignedProtocol[] = "httpS,hTtp";
+        
+        $expected = array();
+        $expected[] = "https";
+        $expected[] = "https,http";
+        
+        for ($i = 0; $i < count($authorizedSignedProtocol); $i++) {
+            // Test
+            $actual = $validateAndSanitizeSignedProtocol->invokeArgs($sasHelper, array($authorizedSignedProtocol[$i]));
+
+            // Assert
+            $this->assertEquals($expected[$i], $actual);
+        }
+    }
+
+    /**
+     * @covers MicrosoftAzure\Storage\Common\Internal\Authentication\SharedAccessSignatureHelper::validateAndSanitizeSignedProtocol
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage is invalid
+     */
+    public function testValidateAndSanitizeSignedProtocolThrowsException()
+    {
+        // Setup
+        $sasHelper = $this->testConstruct();
+        $validateAndSanitizeSignedProtocol = self::getMethod('validateAndSanitizeSignedProtocol', $sasHelper);
+        
+        $unauthorizedSignedProtocol = "htTp";
+
+        // Test: should throw an InvalidArgumentException
+        $validateAndSanitizeSignedProtocol->invokeArgs($sasHelper, array($unauthorizedSignedProtocol));
+    }
+
+    public function testGenerateAccountSharedAccessSignatureToken()
+    {
+        // Setup
+        $accountName = "phptests";
+        $accountKey = "WaZvixrkMok53QDmj8Tc99+BV6vO9cCOJNsdm+wD9QVEScwl8c1eYPcQ182ndNFqxX1+SEKs18SmOxh8OpzIUg==";
+
+        // Test
+        $sasHelper = new SharedAccessSignatureHelper($accountName, $accountKey);
+
+        // create the test cases
+        $testCases = GenerateAccountSASTestCase::BuildTestCases();
+        
+        foreach($testCases as $testCase) {
+
+            // test
+            $actualSignature = $sasHelper->generateAccountSharedAccessSignatureToken(
+                $testCase->getSignedVersion(),
+                $testCase->getSignedPermission(),
+                $testCase->getSignedService(),
+                $testCase->getSignedResourceType(),
+                $testCase->getSignedExpiracy(),
+                $testCase->getSignedStart(),
+                $testCase->getSignedIP(),
+                $testCase->getSignedProtocol()
+            );
+
+            // assert
+            $this->assertEquals($testCase->getExpectedSignature(), urlencode($actualSignature));
+        }
+    }
+}
+
+class GenerateAccountSASTestCase {
+
+    protected $signedVersion;
+    protected $signedService;
+    protected $signedResourceType;
+    protected $signedPermission;
+    protected $signedExpiracy;
+    protected $signedStart;
+    protected $signedProtocol;
+    protected $signedIP;
+    protected $expectedSignature;
+
+    public function __construct(
+        $signedVersion,
+        $signedService,
+        $signedResourceType,
+        $signedPermission,
+        $signedExpiracy,
+        $signedStart,
+        $signedProtocol,
+        $signedIP,
+        $expectedSignature
+    ) {
+        $this->signedVersion = $signedVersion;
+        $this->signedService = $signedService;
+        $this->signedResourceType = $signedResourceType;
+        $this->signedPermission = $signedPermission;
+        $this->signedExpiracy = $signedExpiracy;
+        $this->signedStart = $signedStart;
+        $this->signedProtocol = $signedProtocol;
+        $this->signedIP = $signedIP;
+        $this->expectedSignature = $expectedSignature;
+    }
+
+    public function getSignedVersion() {
+        return $this->signedVersion;
+    }
+
+    public function getSignedService() {
+        return $this->signedService;
+    }
+    
+    public function getSignedResourceType() {
+        return $this->signedResourceType;
+    }
+    
+    public function getSignedPermission() {
+        return $this->signedPermission;
+    }
+    
+    public function getSignedExpiracy() {
+        return $this->signedExpiracy;
+    }
+    
+    public function getSignedStart() {
+        return $this->signedStart;
+    }
+    
+    public function getSignedProtocol() {
+        return $this->signedProtocol;
+    }
+    
+    public function getSignedIP() {
+        return $this->signedIP;
+    }
+    
+    public function getExpectedSignature() {
+        return $this->expectedSignature;
+    }
+
+    public static function BuildTestCases() {
+        $testCases = array();
+
+        // ?sv=2016-05-31&ss=bfqt&srt=sco&sp=rwdlacup&se=2017-03-24T21:14:01Z&st=2017-03-17T13:14:01Z&spr=https&sig=ZpEYbkT%2B9NJTYyMIuFnXQ9RzOehYF1mjnsk00B%2FX1nw%3D
+        $testCases[] = new GenerateAccountSASTestCase(
+            "2016-05-31", // signedVersion
+            "bfqt", // signedService
+            "sco", // signedResourceType
+            "rwdlacup", // signedPermission
+            "2017-03-24T21:14:01Z", // signedExpiracy
+            "2017-03-17T13:14:01Z", // signedStart
+            "https", // signedProtocol
+            "", // signedIP
+            "ZpEYbkT%2B9NJTYyMIuFnXQ9RzOehYF1mjnsk00B%2FX1nw%3D" // expectedSignature
+        );
+
+        // ?sv=2016-05-31&ss=bfqt&srt=sco&sp=rwdlacup&se=2017-03-24T21:14:01Z&st=2017-03-17T13:14:01Z&sip=168.1.5.65&spr=https,http&sig=GZcWRjLJk%2FJSbM9zKb1XufTt2OueTSSgwsa03nYn5yM%3D
+        $testCases[] = new GenerateAccountSASTestCase(
+            "2016-05-31", // signedVersion
+            "bfqt", // signedService
+            "sco", // signedResourceType
+            "rwdlacup", // signedPermission
+            "2017-03-24T21:14:01Z", // signedExpiracy
+            "2017-03-17T13:14:01Z", // signedStart
+            "https,http", // signedProtocol
+            "168.1.5.65", // signedIP
+            "GZcWRjLJk%2FJSbM9zKb1XufTt2OueTSSgwsa03nYn5yM%3D" // expectedSignature
+        );
+
+        // ?sv=2016-05-31&ss=bf&srt=s&sp=rw&se=2017-03-24T00:00:00Z&st=2017-03-17T00:00:00Z&spr=https&sig=1%2BAozefG5VZDx9XorEGrAjOiTS8dX%2BJelK5SW91Zvq0%3D
+        $testCases[] = new GenerateAccountSASTestCase(
+            "2016-05-31", // signedVersion
+            "bf", // signedService
+            "s", // signedResourceType
+            "rw", // signedPermission
+            "2017-03-24T00:00:00Z", // signedExpiracy
+            "2017-03-17T00:00:00Z", // signedStart
+            "https", // signedProtocol
+            "", // signedIP
+            "1%2BAozefG5VZDx9XorEGrAjOiTS8dX%2BJelK5SW91Zvq0%3D" // expectedSignature
+        );
+
+        // ?sv=2016-05-31&ss=q&srt=o&sp=up&se=2017-03-24T00:00:00Z&st=2017-03-17T00:00:00Z&spr=https&sig=k1BKI65TdXs7rdAJiqDSJ6wYHjfJD0CJgplvOyqBK7Y%3D
+        $testCases[] = new GenerateAccountSASTestCase(
+            "2016-05-31", // signedVersion
+            "q", // signedService
+            "o", // signedResourceType
+            "up", // signedPermission
+            "2017-03-24T00:00:00Z", // signedExpiracy
+            "2017-03-17T00:00:00Z", // signedStart
+            "https", // signedProtocol
+            "", // signedIP
+            "k1BKI65TdXs7rdAJiqDSJ6wYHjfJD0CJgplvOyqBK7Y%3D" // expectedSignature
+        );
+
+        return $testCases;
+    }
+}


### PR DESCRIPTION
- Add the `SharedAccessSignatureHelper` class with `generateAccountSharedAccessSignatureToken` function
- Add the `SharedAccessSignatureHelperTest` class that contains unit tests for the SharedAccessSignatureHelper class