### PR TITLE
Check if the value is numeric string first before is_double()

### DIFF
--- a/src/Common/Internal/Utilities.php
+++ b/src/Common/Internal/Utilities.php
@@ -848,7 +848,7 @@ class Utilities
      */
     public static function isDouble($value)
     {
-        return is_double($value + 0);
+        return is_numeric($value) && is_double($value + 0);
     }
 
     /**


### PR DESCRIPTION
Otherwise it throws a warning on PHP 7.1

Fixes #86