### PR TITLE
Disable warnings when parsing possibly non-XML strings

### DIFF
--- a/src/Common/Exceptions/ServiceException.php
+++ b/src/Common/Exceptions/ServiceException.php
@@ -86,7 +86,18 @@ class ServiceException extends \LogicException
         $serializer = new XMLSerializer();
         $errorMessage = '';
         try {
+            $internalErrors = libxml_use_internal_errors(true);
             $parsedArray = $serializer->unserialize($response->getBody());
+            $messages = array();
+            foreach (libxml_get_errors() as $error) {
+                $messages[] = $error->message;
+            }
+            if (!empty($messages)) {
+                throw new \Exception(
+                    sprintf(Resources::ERROR_CANNOT_PARSE_XML, implode('; ', $messages))
+                );
+            }
+            libxml_use_internal_errors($internalErrors);
             if (array_key_exists(Resources::XTAG_MESSAGE, $parsedArray)) {
                 $errorMessage = $parsedArray[Resources::XTAG_MESSAGE];
             } else {

--- a/src/Common/Internal/Resources.php
+++ b/src/Common/Internal/Resources.php
@@ -140,6 +140,7 @@ class Resources
     const FILE_SHARE_PROPERTIES_OPERATION_INVALID = "The operation is invalid. Can only be 'metadata' or 'properties'.";
     const RESOURCE_RANGE_LENGTH_MUST_SET = "The start and end/length of the range must be set.";
     const INVALID_ACCEPT_CONTENT_TYPE = "The given accept content type is not valid.";
+    const ERROR_CANNOT_PARSE_XML = "Cannot parse XML, reasons: %s";
 
     // HTTP Headers
     const X_MS_HEADER_PREFIX                 = 'x-ms-';

--- a/tests/framework/TestResources.php
+++ b/tests/framework/TestResources.php
@@ -65,6 +65,7 @@ class TestResources
     const REQUEST_ID1   = 'f16b5298-0003-011e-0e70-83666b000000';
     const REQUEST_ID2   = 'c17dcd76-0003-0046-1c70-832445000000';
     const RESPONSE_BODY = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>InvalidResourceName</Code><Message>The specifed resource name contains invalid characters.\nRequestId:f16b5298-0003-011e-0e70-83666b000000\nTime:2017-02-10T07:36:04.8329883Z</Message></Error>";
+    const RESPONSE_BODY_JSON = '{"odata.error":{"code":"ResourceNotFound","message":{"lang":"en-US","value":"Test"}}}';
     const ERROR_MESSAGE = "The specifed resource name contains invalid characters.\nRequestId:f16b5298-0003-011e-0e70-83666b000000\nTime:2017-02-10T07:36:04.8329883Z";
     const VALID_URL     = 'http://www.example.com';
     const HEADER1       = 'testheader1';
@@ -438,6 +439,17 @@ class TestResources
                 Resources::X_MS_REQUEST_ID => self::REQUEST_ID1
             ),
             self::RESPONSE_BODY,
+            '1.1',
+            $reason
+        );
+    }
+
+    public static function getFailedResponseJson($statusCode, $reason)
+    {
+        return new Response(
+            $statusCode,
+            array(),
+            self::RESPONSE_BODY_JSON,
             '1.1',
             $reason
         );

--- a/tests/unit/Common/Exceptions/ServiceExceptionTest.php
+++ b/tests/unit/Common/Exceptions/ServiceExceptionTest.php
@@ -131,4 +131,22 @@ class ServiceExceptionTest extends \PHPUnit_Framework_TestCase
         // Assert
         $this->assertEquals($e->getResponse(), $response);
     }
+
+    /**
+     * @covers MicrosoftAzure\Storage\Common\Exceptions\ServiceException::__construct
+     * @covers MicrosoftAzure\Storage\Common\Exceptions\ServiceException::parseErrorMessage
+     */
+    public function testNoWarningForNonXmlErrorMessage()
+    {
+        // Warnings are silenced in parseErrorMessage once they are converted to exceptions
+        \PHPUnit_Framework_Error_Warning::$enabled = false;
+
+        // Setup
+        $response = TestResources::getFailedResponseJson(210, 'test info');
+        $e = new ServiceException($response);
+
+        // Assert
+        $this->assertEquals($e->getErrorMessage(), TestResources::RESPONSE_BODY_JSON);
+    }
+
 }


### PR DESCRIPTION
Fixes #88 