### PR TITLE
Fix formatting of non-UTC dates

### DIFF
--- a/src/Common/Internal/Utilities.php
+++ b/src/Common/Internal/Utilities.php
@@ -368,27 +368,15 @@ class Utilities
     /**
      * Generate ISO 8601 compliant date string in UTC time zone
      *
-     * @param int $timestamp The unix timestamp to convert
-     *     (for DateTime check date_timestamp_get).
+     * @param \DateTimeInterface $date The date value to convert
      *
      * @return string
      */
-    public static function isoDate($timestamp = null)
+    public static function isoDate(\DateTimeInterface $date)
     {
-        $tz = date_default_timezone_get();
-        date_default_timezone_set('UTC');
+        $date = (clone $date)->setTimezone(new \DateTimeZone('UTC'));
 
-        if (is_null($timestamp)) {
-            $timestamp = time();
-        }
-
-        $returnValue = str_replace(
-            '+00:00',
-            '.0000000Z',
-            date('c', $timestamp)
-        );
-        date_default_timezone_set($tz);
-        return $returnValue;
+        return str_replace('+00:00', 'Z', $date->format('c'));
     }
 
     /**

--- a/src/Common/SharedAccessSignatureHelper.php
+++ b/src/Common/SharedAccessSignatureHelper.php
@@ -127,14 +127,14 @@ class SharedAccessSignatureHelper
         );
         // check that expiracy is valid
         if ($signedExpiry instanceof \Datetime) {
-            $signedExpiry = $signedExpiry->format('Y-m-d\TH:i:s\Z');
+            $signedExpiry = Utilities::isoDate($signedExpiry);
         }
         Validate::notNullOrEmpty($signedExpiry, 'signedExpiry');
         Validate::canCastAsString($signedExpiry, 'signedExpiry');
         Validate::isDateString($signedExpiry, 'signedExpiry');
         // check that signed start is valid
         if ($signedStart instanceof \Datetime) {
-            $signedStart = $signedStart->format('Y-m-d\TH:i:s\Z');
+            $signedStart = Utilities::isoDate($signedStart);
         }
         Validate::canCastAsString($signedStart, 'signedStart');
         if (strlen($signedStart) > 0) {
@@ -560,7 +560,7 @@ class SharedAccessSignatureHelper
 
         // check that expiracy is valid
         if ($signedExpiry instanceof \Datetime) {
-            $signedExpiry = $signedExpiry->format('Y-m-d\TH:i:s\Z');
+            $signedExpiry = Utilities::isoDate($signedExpiry);
         }
         Validate::canCastAsString($signedExpiry, 'signedExpiry');
         Validate::notNullOrEmpty($signedExpiry, 'signedExpiry');
@@ -568,7 +568,7 @@ class SharedAccessSignatureHelper
 
         // check that signed start is valid
         if ($signedStart instanceof \Datetime) {
-            $signedStart = $signedStart->format('Y-m-d\TH:i:s\Z');
+            $signedStart = Utilities::isoDate($signedStart);
         }
         Validate::canCastAsString($signedStart, 'signedStart');
         if (strlen($signedStart) > 0) {

--- a/tests/framework/TestResources.php
+++ b/tests/framework/TestResources.php
@@ -1502,7 +1502,7 @@ class TestResources
         $signedIP = ""
     ) {
         if ($signedExpiry == "") {
-            $signedExpiry = (self::getRandomLaterTime()->format('Y-m-d\TH:i:s\Z'));
+            $signedExpiry = Utilities::isoDate(self::getRandomLaterTime());
         }
 
         if ($signedStart == "") {
@@ -1540,7 +1540,7 @@ class TestResources
         $contentType = ""
     ) {
         if ($signedExpiry == "") {
-            $signedExpiry = (self::getRandomLaterTime()->format('Y-m-d\TH:i:s\Z'));
+            $signedExpiry = Utilities::isoDate(self::getRandomLaterTime());
         }
 
         if ($signedStart == "") {
@@ -1581,11 +1581,11 @@ class TestResources
         $endingRowKey = ""
     ) {
         if ($signedExpiry == "") {
-            $signedExpiry = (self::getRandomLaterTime()->format('Y-m-d\TH:i:s\Z'));
+            $signedExpiry = Utilities::isoDate(self::getRandomLaterTime());
         }
 
         if ($signedStart == "") {
-            $signedStart = (self::getRandomEarlierTime()->format('Y-m-d\TH:i:s\Z'));
+            $signedStart = Utilities::isoDate(self::getRandomEarlierTime());
         }
 
         if ($signedIP == "") {
@@ -1616,11 +1616,11 @@ class TestResources
         $signedIP = ""
     ) {
         if ($signedExpiry == "") {
-            $signedExpiry = (self::getRandomLaterTime()->format('Y-m-d\TH:i:s\Z'));
+            $signedExpiry = Utilities::isoDate(self::getRandomLaterTime());
         }
 
         if ($signedStart == "") {
-            $signedStart = (self::getRandomEarlierTime()->format('Y-m-d\TH:i:s\Z'));
+            $signedStart = Utilities::isoDate(self::getRandomEarlierTime());
         }
 
         if ($signedIP == "") {

--- a/tests/unit/Common/Internal/UtilitiesTest.php
+++ b/tests/unit/Common/Internal/UtilitiesTest.php
@@ -332,10 +332,10 @@ class UtilitiesTest extends \PHPUnit_Framework_TestCase
     public function testIsoDate()
     {
         // Test
-        $date = Utilities::isoDate();
+        $date = Utilities::isoDate(new \DateTimeImmutable('2016-02-03', new \DateTimeZone('America/Chicago')));
 
         // Assert
-        $this->assertNotNull($date);
+        $this->assertSame('2016-02-03T06:00:00Z', $date);
     }
 
     /**

--- a/tests/unit/Table/Models/EntityTest.php
+++ b/tests/unit/Table/Models/EntityTest.php
@@ -122,7 +122,7 @@ class EntityTest extends \PHPUnit_Framework_TestCase
     {
         // Setup
         $entity = new Entity();
-        $expected = Utilities::convertToDateTime(Utilities::isoDate());
+        $expected = new \DateTime();
         
         // Test
         $entity->setTimestamp($expected);


### PR DESCRIPTION
When using instances of `DateTime` to generate shared access signatures, the current code assumes the timezone is always set to UTC. This leads to problems, especially when `$expiryStart` is used in territories with a positive timezone offset (e.g. Asia). After applying this patch, the dates are correctly normalized even when used outside UTC.