### PR TITLE
Fixed a syntax error for PHP 5.5 and 5.6 in `MicrosoftAzure\Storage\C…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+2017.09 - version 0.19.1
+
+ALL
+* Fixed a syntax error for PHP 5.5 and 5.6 in `MicrosoftAzure\Storage\Common\Internal::Utilities:isoDate`.
+
 2017.09 - version 0.19.0
 
 ALL

--- a/src/Common/Internal/Resources.php
+++ b/src/Common/Internal/Resources.php
@@ -307,7 +307,7 @@ class Resources
     const DEAFULT_RETRY_INTERVAL = 1000;//Milliseconds
 
     // Header values
-    const SDK_VERSION                        = '0.19.0';
+    const SDK_VERSION                        = '0.19.1';
     const STORAGE_API_LATEST_VERSION         = '2016-05-31';
     const DATA_SERVICE_VERSION_VALUE         = '3.0';
     const MAX_DATA_SERVICE_VERSION_VALUE     = '3.0;NetFx';

--- a/src/Common/Internal/Utilities.php
+++ b/src/Common/Internal/Utilities.php
@@ -374,7 +374,8 @@ class Utilities
      */
     public static function isoDate(\DateTimeInterface $date)
     {
-        $date = (clone $date)->setTimezone(new \DateTimeZone('UTC'));
+        $date = clone $date;
+        $date = $date->setTimezone(new \DateTimeZone('UTC'));
 
         return str_replace('+00:00', 'Z', $date->format('c'));
     }

--- a/tests/Unit/Blob/Models/CopyBlobOptionsTest.php
+++ b/tests/Unit/Blob/Models/CopyBlobOptionsTest.php
@@ -140,8 +140,6 @@ class CopyBlobOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers MicrosoftAzure\Storage\Blob\Models\CopyBlobFromURLOptions::setSourceSnapshot
-     * @covers MicrosoftAzure\Storage\Blob\Models\CopyBlobFromURLOptions::getSourceSnapshot
      * @covers MicrosoftAzure\Storage\Blob\Models\CopyBlobOptions::setSourceSnapshot
      * @covers MicrosoftAzure\Storage\Blob\Models\CopyBlobOptions::getSourceSnapshot
      */


### PR DESCRIPTION
…ommon\Internal::Utilities:isoDate`.