### PR TITLE
Correct namespace for Resources

### DIFF
--- a/src/Common/Logger.php
+++ b/src/Common/Logger.php
@@ -24,6 +24,8 @@
  
 namespace MicrosoftAzure\Storage\Common;
 
+use MicrosoftAzure\Storage\Common\Internal\Resources;
+
 /**
  * Logger class for debugging purpose.
  *


### PR DESCRIPTION
`MicrosoftAzure\Storage\Common\Internal\Logger` was moved to `MicrosoftAzure\Storage\Common\Logger` in v0.14.0 commit 1f9647f31a64f1d4d7b9c6bdef8533a0d88877c6

Found with the great [PHPStan](https://github.com/phpstan/phpstan) static analyzer by unintentionally running it on vendor folder.