### PR TITLE
Change type according to EdmType specified when serializing

### DIFF
--- a/src/Table/Models/EdmType.php
+++ b/src/Table/Models/EdmType.php
@@ -170,12 +170,16 @@ class EdmType
     public static function serializeValue($type, $value)
     {
         switch ($type) {
+        case null:
+            return $value;
+
         case EdmType::INT32:
+            return intval($value);
+
         case EdmType::INT64:
         case EdmType::GUID:
         case EdmType::STRING:
-        case null:
-            return $value;
+            return strval($value);
            
         case EdmType::DOUBLE:
             return strval($value);

--- a/tests/Unit/Table/Models/EdmTypeTest.php
+++ b/tests/Unit/Table/Models/EdmTypeTest.php
@@ -351,6 +351,40 @@ class EdmTypeTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers MicrosoftAzure\Storage\Table\Models\EdmType::serializeValue
      */
+    public function testSerializeValueWithIntAsString()
+    {
+        // Setup
+        $type = EdmType::INT32;
+        $value = '123';
+        $expected = 123;
+        
+        // Test
+        $actual = EdmType::serializeValue($type, $value);
+
+        // Assert
+        $this->assertSame($expected, $actual);
+    }
+    
+    /**
+     * @covers MicrosoftAzure\Storage\Table\Models\EdmType::serializeValue
+     */
+    public function testSerializeValueWithStringAsInt()
+    {
+        // Setup
+        $type = EdmType::STRING;
+        $value = 123;
+        $expected = '123';
+        
+        // Test
+        $actual = EdmType::serializeValue($type, $value);
+
+        // Assert
+        $this->assertSame($expected, $actual);
+    }
+    
+    /**
+     * @covers MicrosoftAzure\Storage\Table\Models\EdmType::serializeValue
+     */
     public function testSerializeValueWithBoolean()
     {
         // Setup


### PR DESCRIPTION
Allows passing a string into Int32 property, and an integer to String property, while maintaining the property type specified

Fixes #114