### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.8.35",
         "mikey179/vfsStream": "~1.6",
         "pdepend/pdepend" : "~2.2",
         "sebastian/phpcpd": "~2.0",

--- a/tests/Framework/ReflectionTestBase.php
+++ b/tests/Framework/ReflectionTestBase.php
@@ -23,7 +23,7 @@
  */
 namespace MicrosoftAzure\Storage\Tests\Framework;
 
-class ReflectionTestBase extends \PHPUnit_Framework_TestCase
+class ReflectionTestBase extends \PHPUnit\Framework\TestCase
 {
     protected static function getMethod($name, $object)
     {

--- a/tests/Framework/RestProxyTestBase.php
+++ b/tests/Framework/RestProxyTestBase.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Common\ServicesBuilder;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class RestProxyTestBase extends \PHPUnit_Framework_TestCase
+class RestProxyTestBase extends \PHPUnit\Framework\TestCase
 {
     protected $restProxy;
     protected $xmlSerializer;

--- a/tests/Framework/SASFunctionalTestBase.php
+++ b/tests/Framework/SASFunctionalTestBase.php
@@ -45,7 +45,7 @@ use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class SASFunctionalTestBase extends \PHPUnit_Framework_TestCase
+class SASFunctionalTestBase extends \PHPUnit\Framework\TestCase
 {
     protected $connectionString;
     protected $xmlSerializer;

--- a/tests/Functional/Blob/AnonymousAccessFunctionalTest.php
+++ b/tests/Functional/Blob/AnonymousAccessFunctionalTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Blob\Models\PublicAccessType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class AnonymousAccessFunctionalTest extends \PHPUnit_Framework_TestCase
+class AnonymousAccessFunctionalTest extends \PHPUnit\Framework\TestCase
 {
     private $containerName;
     private static $blobRestProxy;

--- a/tests/Functional/Queue/QueueServiceFunctionalOptionsTest.php
+++ b/tests/Functional/Queue/QueueServiceFunctionalOptionsTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Queue\Models\ListQueuesOptions;
 use MicrosoftAzure\Storage\Queue\Models\PeekMessagesOptions;
 use MicrosoftAzure\Storage\Queue\Models\QueueServiceOptions;
 
-class QueueServiceFunctionalOptionsTest extends \PHPUnit_Framework_TestCase
+class QueueServiceFunctionalOptionsTest extends \PHPUnit\Framework\TestCase
 {
     const INT_MAX_VALUE = 2147483647;
     const INT_MIN_VALUE = -2147483648;

--- a/tests/Functional/Table/TableServiceFunctionalOptionsTest.php
+++ b/tests/Functional/Table/TableServiceFunctionalOptionsTest.php
@@ -43,7 +43,7 @@ use MicrosoftAzure\Storage\Table\Models\Filters\PropertyNameFilter;
 use MicrosoftAzure\Storage\Table\Models\Filters\QueryStringFilter;
 use MicrosoftAzure\Storage\Table\Models\Filters\UnaryFilter;
 
-class TableServiceFunctionalOptionsTest extends \PHPUnit_Framework_TestCase
+class TableServiceFunctionalOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testCheckTableServiceOptions()
     {

--- a/tests/Unit/Blob/Models/AccessConditionTest.php
+++ b/tests/Unit/Blob/Models/AccessConditionTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class AccessConditionTest extends \PHPUnit_Framework_TestCase
+class AccessConditionTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Blob/Models/BlobBlockTypeTest.php
+++ b/tests/Unit/Blob/Models/BlobBlockTypeTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Blob\Models\BlobBlockType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BlobBlockTypeTest extends \PHPUnit_Framework_TestCase
+class BlobBlockTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testBlobBlockType()
     {

--- a/tests/Unit/Blob/Models/BlobPrefixTest.php
+++ b/tests/Unit/Blob/Models/BlobPrefixTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BlobPrefixTest extends \PHPUnit_Framework_TestCase
+class BlobPrefixTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetName()
     {

--- a/tests/Unit/Blob/Models/BlobPropertiesTest.php
+++ b/tests/Unit/Blob/Models/BlobPropertiesTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BlobPropertiesTest extends \PHPUnit_Framework_TestCase
+class BlobPropertiesTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/BlobTest.php
+++ b/tests/Unit/Blob/Models/BlobTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\BlobProperties;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BlobTest extends \PHPUnit_Framework_TestCase
+class BlobTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetName()
     {

--- a/tests/Unit/Blob/Models/BlobTypeTest.php
+++ b/tests/Unit/Blob/Models/BlobTypeTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Blob\Models\BlobType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BlobTypeTest extends \PHPUnit_Framework_TestCase
+class BlobTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testBlobType()
     {

--- a/tests/Unit/Blob/Models/BlockListTest.php
+++ b/tests/Unit/Blob/Models/BlockListTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Blob\Models\Block;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BlockListTest extends \PHPUnit_Framework_TestCase
+class BlockListTest extends \PHPUnit\Framework\TestCase
 {
     public function testAddEntry()
     {

--- a/tests/Unit/Blob/Models/BlockTest.php
+++ b/tests/Unit/Blob/Models/BlockTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Blob\Models\Block;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BlockTest extends \PHPUnit_Framework_TestCase
+class BlockTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetBlockId()
     {

--- a/tests/Unit/Blob/Models/BreakLeaseResultTest.php
+++ b/tests/Unit/Blob/Models/BreakLeaseResultTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Blob\Models\BreakLeaseResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BreakLeaseResultTest extends \PHPUnit_Framework_TestCase
+class BreakLeaseResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/CommitBlobBlocksOptionsTest.php
+++ b/tests/Unit/Blob/Models/CommitBlobBlocksOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Blob\Models\AccessCondition;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CommitBlobBlocksOptionsTest extends \PHPUnit_Framework_TestCase
+class CommitBlobBlocksOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetContentType()
     {

--- a/tests/Unit/Blob/Models/ContainerACLTest.php
+++ b/tests/Unit/Blob/Models/ContainerACLTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Serialization\XmlSerializer;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ContainerACLTest extends \PHPUnit_Framework_TestCase
+class ContainerACLTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateEmpty()
     {

--- a/tests/Unit/Blob/Models/ContainerPropertiesTest.php
+++ b/tests/Unit/Blob/Models/ContainerPropertiesTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Blob\Models\ContainerProperties;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ContainerPropertiesTest extends \PHPUnit_Framework_TestCase
+class ContainerPropertiesTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetETag()
     {

--- a/tests/Unit/Blob/Models/ContainerTest.php
+++ b/tests/Unit/Blob/Models/ContainerTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ContainerTest extends \PHPUnit_Framework_TestCase
+class ContainerTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetName()
     {

--- a/tests/Unit/Blob/Models/CopyBlobOptionsTest.php
+++ b/tests/Unit/Blob/Models/CopyBlobOptionsTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Blob\Models\CopyBlobOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CopyBlobOptionsTest extends \PHPUnit_Framework_TestCase
+class CopyBlobOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetMetadata()
     {

--- a/tests/Unit/Blob/Models/CopyBlobResultTest.php
+++ b/tests/Unit/Blob/Models/CopyBlobResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CopyBlobResultTest extends \PHPUnit_Framework_TestCase
+class CopyBlobResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/CreateBlobBlockOptionsTest.php
+++ b/tests/Unit/Blob/Models/CreateBlobBlockOptionsTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Blob\Models\CreateBlobBlockOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateBlobBlockOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateBlobBlockOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetContentMD5()
     {

--- a/tests/Unit/Blob/Models/CreateBlobOptionsTest.php
+++ b/tests/Unit/Blob/Models/CreateBlobOptionsTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Blob\Models\AccessCondition;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateBlobOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateBlobOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetContentType()
     {

--- a/tests/Unit/Blob/Models/CreateBlobPagesOptionsTest.php
+++ b/tests/Unit/Blob/Models/CreateBlobPagesOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Blob\Models\AccessCondition;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateBlobPagesOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateBlobPagesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetAccessConditions()
     {

--- a/tests/Unit/Blob/Models/CreateBlobPagesResultTest.php
+++ b/tests/Unit/Blob/Models/CreateBlobPagesResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\CreateBlobPagesResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateBlobPagesResultTest extends \PHPUnit_Framework_TestCase
+class CreateBlobPagesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/CreateBlobSnapshotOptionsTest.php
+++ b/tests/Unit/Blob/Models/CreateBlobSnapshotOptionsTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\CreateBlobSnapshotOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateBlobSnapshotOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateBlobSnapshotOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetMetadata()
     {

--- a/tests/Unit/Blob/Models/CreateBlobSnapshotResultTest.php
+++ b/tests/Unit/Blob/Models/CreateBlobSnapshotResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\CreateBlobSnapshotResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateBlobSnapshotResultTest extends \PHPUnit_Framework_TestCase
+class CreateBlobSnapshotResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/CreateContainerOptionsTest.php
+++ b/tests/Unit/Blob/Models/CreateContainerOptionsTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Common\Exceptions\InvalidArgumentTypeException;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateContainerOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateContainerOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetPublicAccess()
     {

--- a/tests/Unit/Blob/Models/DeleteBlobOptionsTest.php
+++ b/tests/Unit/Blob/Models/DeleteBlobOptionsTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\DeleteBlobOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class DeleteBlobOptionsTest extends \PHPUnit_Framework_TestCase
+class DeleteBlobOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetLeaseId()
     {

--- a/tests/Unit/Blob/Models/GetBlobMetadataOptionsTest.php
+++ b/tests/Unit/Blob/Models/GetBlobMetadataOptionsTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\GetBlobMetadataOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetBlobMetadataOptionsTest extends \PHPUnit_Framework_TestCase
+class GetBlobMetadataOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetLeaseId()
     {

--- a/tests/Unit/Blob/Models/GetBlobMetadataResultTest.php
+++ b/tests/Unit/Blob/Models/GetBlobMetadataResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\GetBlobMetadataResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetBlobMetadataResultTest extends \PHPUnit_Framework_TestCase
+class GetBlobMetadataResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/GetBlobOptionsTest.php
+++ b/tests/Unit/Blob/Models/GetBlobOptionsTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Blob\Models\GetBlobOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetBlobOptionsTest extends \PHPUnit_Framework_TestCase
+class GetBlobOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetLeaseId()
     {

--- a/tests/Unit/Blob/Models/GetBlobPropertiesOptionsTest.php
+++ b/tests/Unit/Blob/Models/GetBlobPropertiesOptionsTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\GetBlobPropertiesOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetBlobPropertiesOptionsTest extends \PHPUnit_Framework_TestCase
+class GetBlobPropertiesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetLeaseId()
     {

--- a/tests/Unit/Blob/Models/GetBlobPropertiesResultTest.php
+++ b/tests/Unit/Blob/Models/GetBlobPropertiesResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\BlobProperties;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetBlobPropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetBlobPropertiesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/GetBlobResultTest.php
+++ b/tests/Unit/Blob/Models/GetBlobResultTest.php
@@ -39,7 +39,7 @@ use GuzzleHttp\Psr7;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetBlobResultTest extends \PHPUnit_Framework_TestCase
+class GetBlobResultTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testCreate()

--- a/tests/Unit/Blob/Models/GetContainerACLResultTest.php
+++ b/tests/Unit/Blob/Models/GetContainerACLResultTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetContainerACLResultTest extends \PHPUnit_Framework_TestCase
+class GetContainerACLResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/GetContainerPropertiesResultTest.php
+++ b/tests/Unit/Blob/Models/GetContainerPropertiesResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetContainerPropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetContainerPropertiesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/LeaseModeTest.php
+++ b/tests/Unit/Blob/Models/LeaseModeTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Blob\Models\LeaseMode;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class LeaseModeTest extends \PHPUnit_Framework_TestCase
+class LeaseModeTest extends \PHPUnit\Framework\TestCase
 {
     public function testLeaseMode()
     {

--- a/tests/Unit/Blob/Models/LeaseResultTest.php
+++ b/tests/Unit/Blob/Models/LeaseResultTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Blob\Models\LeaseResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class LeaseResultTest extends \PHPUnit_Framework_TestCase
+class LeaseResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/ListBlobBlocksOptionsTest.php
+++ b/tests/Unit/Blob/Models/ListBlobBlocksOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Blob\Models\ListBlobBlocksOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListBlobBlocksOptionsTest extends \PHPUnit_Framework_TestCase
+class ListBlobBlocksOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetSnapshot()
     {

--- a/tests/Unit/Blob/Models/ListBlobBlocksResultTest.php
+++ b/tests/Unit/Blob/Models/ListBlobBlocksResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListBlobBlocksResultTest extends \PHPUnit_Framework_TestCase
+class ListBlobBlocksResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/ListBlobsOptionsTest.php
+++ b/tests/Unit/Blob/Models/ListBlobsOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListBlobsOptionsTest extends \PHPUnit_Framework_TestCase
+class ListBlobsOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetPrefix()
     {

--- a/tests/Unit/Blob/Models/ListBlobsResultTest.php
+++ b/tests/Unit/Blob/Models/ListBlobsResultTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListBlobsResultTest extends \PHPUnit_Framework_TestCase
+class ListBlobsResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateWithEmpty()
     {

--- a/tests/Unit/Blob/Models/ListContainersOptionsTest.php
+++ b/tests/Unit/Blob/Models/ListContainersOptionsTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListContainersOptionsTest extends \PHPUnit_Framework_TestCase
+class ListContainersOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetPrefix()
     {

--- a/tests/Unit/Blob/Models/ListContainersResultTest.php
+++ b/tests/Unit/Blob/Models/ListContainersResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListContainersResultTest extends \PHPUnit_Framework_TestCase
+class ListContainersResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateWithEmpty()
     {

--- a/tests/Unit/Blob/Models/ListPageBlobRangesDiffResultTest.php
+++ b/tests/Unit/Blob/Models/ListPageBlobRangesDiffResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListPageBlobRangesDiffResultTest extends \PHPUnit_Framework_TestCase
+class ListPageBlobRangesDiffResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/ListPageBlobRangesOptionsTest.php
+++ b/tests/Unit/Blob/Models/ListPageBlobRangesOptionsTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListPageBlobRangesOptionsTest extends \PHPUnit_Framework_TestCase
+class ListPageBlobRangesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetLeaseId()
     {

--- a/tests/Unit/Blob/Models/ListPageBlobRangesResultTest.php
+++ b/tests/Unit/Blob/Models/ListPageBlobRangesResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListPageBlobRangesResultTest extends \PHPUnit_Framework_TestCase
+class ListPageBlobRangesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/PublicAccessTypeTest.php
+++ b/tests/Unit/Blob/Models/PublicAccessTypeTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class PublicAccessTypeTest extends \PHPUnit_Framework_TestCase
+class PublicAccessTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testPublicAccessType()
     {

--- a/tests/Unit/Blob/Models/PutBlobResultTest.php
+++ b/tests/Unit/Blob/Models/PutBlobResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\PutBlobResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class PutBlobResultTest extends \PHPUnit_Framework_TestCase
+class PutBlobResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/PutBlockResultTest.php
+++ b/tests/Unit/Blob/Models/PutBlockResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Blob\Models\PutBlockResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class PutBlockResultTest extends \PHPUnit_Framework_TestCase
+class PutBlockResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/SetBlobMetadataResultTest.php
+++ b/tests/Unit/Blob/Models/SetBlobMetadataResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class SetBlobMetadataResultTest extends \PHPUnit_Framework_TestCase
+class SetBlobMetadataResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/SetBlobPropertiesOptionsTest.php
+++ b/tests/Unit/Blob/Models/SetBlobPropertiesOptionsTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Blob\Models\BlobProperties;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class SetBlobPropertiesOptionsTest extends \PHPUnit_Framework_TestCase
+class SetBlobPropertiesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testconstruct()
     {

--- a/tests/Unit/Blob/Models/SetBlobPropertiesResultTest.php
+++ b/tests/Unit/Blob/Models/SetBlobPropertiesResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class SetBlobPropertiesResultTest extends \PHPUnit_Framework_TestCase
+class SetBlobPropertiesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Blob/Models/SignedIdentifierTest.php
+++ b/tests/Unit/Blob/Models/SignedIdentifierTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Models\SignedIdentifier;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class SignedIdentifierTest extends \PHPUnit_Framework_TestCase
+class SignedIdentifierTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetId()
     {

--- a/tests/Unit/Common/CloudConfigurationManagerTest.php
+++ b/tests/Unit/Common/CloudConfigurationManagerTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Common\Internal\ConnectionStringSource;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CloudConfigurationManagerTest extends \PHPUnit_Framework_TestCase
+class CloudConfigurationManagerTest extends \PHPUnit\Framework\TestCase
 {
     private $_key = 'my_connection_string';
     private $_value = 'connection string value';

--- a/tests/Unit/Common/Exceptions/ServiceExceptionTest.php
+++ b/tests/Unit/Common/Exceptions/ServiceExceptionTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ServiceExceptionTest extends \PHPUnit_Framework_TestCase
+class ServiceExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Common/Internal/ACLBaseTest.php
+++ b/tests/Unit/Common/Internal/ACLBaseTest.php
@@ -41,7 +41,7 @@ use MicrosoftAzure\Storage\Common\Internal\Serialization\XmlSerializer;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ACLBaseTest extends \PHPUnit_Framework_TestCase
+class ACLBaseTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetGetSignedIdentifiers()
     {

--- a/tests/Unit/Common/Internal/Authentication/SharedAccessSignatureAuthSchemeTest.php
+++ b/tests/Unit/Common/Internal/Authentication/SharedAccessSignatureAuthSchemeTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license    https://github.com/azure/azure-storage-php/LICENSE
  * @link       https://github.com/azure/azure-storage-php
  */
-class SharedAccessSignatureAuthSchemeTest extends \PHPUnit_Framework_TestCase
+class SharedAccessSignatureAuthSchemeTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Common/Internal/Authentication/SharedKeyAuthSchemeTest.php
+++ b/tests/Unit/Common/Internal/Authentication/SharedKeyAuthSchemeTest.php
@@ -40,7 +40,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license    https://github.com/azure/azure-storage-php/LICENSE
  * @link       https://github.com/azure/azure-storage-php
  */
-class SharedKeyAuthSchemeTest extends \PHPUnit_Framework_TestCase
+class SharedKeyAuthSchemeTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Common/Internal/ConnectionStringParserTest.php
+++ b/tests/Unit/Common/Internal/ConnectionStringParserTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Internal\ConnectionStringParser;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ConnectionStringParserTest extends \PHPUnit_Framework_TestCase
+class ConnectionStringParserTest extends \PHPUnit\Framework\TestCase
 {
     private function _parseTest($connectionString)
     {

--- a/tests/Unit/Common/Internal/ConnectionStringSourceTest.php
+++ b/tests/Unit/Common/Internal/ConnectionStringSourceTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Internal\ConnectionStringSource;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ConnectionStringSourceTest extends \PHPUnit_Framework_TestCase
+class ConnectionStringSourceTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Unit/Common/Internal/Http/HttpCallContextTest.php
+++ b/tests/Unit/Common/Internal/Http/HttpCallContextTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Internal\Http\HttpCallContext;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class HttpCallContextTest extends \PHPUnit_Framework_TestCase
+class HttpCallContextTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Common/Internal/InvalidArgumentTypeExceptionTest.php
+++ b/tests/Unit/Common/Internal/InvalidArgumentTypeExceptionTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Exceptions\InvalidArgumentTypeException;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class InvalidArgumentTypeExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentTypeExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Common/Internal/LoggerTest.php
+++ b/tests/Unit/Common/Internal/LoggerTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\VirtualFileSystem;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function testLogWithArray()
     {

--- a/tests/Unit/Common/Internal/Serialization/JsonSerializerTest.php
+++ b/tests/Unit/Common/Internal/Serialization/JsonSerializerTest.php
@@ -40,7 +40,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class JsonSerializerTest extends \PHPUnit_Framework_TestCase
+class JsonSerializerTest extends \PHPUnit\Framework\TestCase
 {
     public function testObjectSerialize()
     {

--- a/tests/Unit/Common/Internal/Serialization/XmlSerializerTest.php
+++ b/tests/Unit/Common/Internal/Serialization/XmlSerializerTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Serialization\XmlSerializer;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class XmlSerializerTest extends \PHPUnit_Framework_TestCase
+class XmlSerializerTest extends \PHPUnit\Framework\TestCase
 {
     public function testUnserialize()
     {

--- a/tests/Unit/Common/Internal/ServiceOptionsTest.php
+++ b/tests/Unit/Common/Internal/ServiceOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Models\ServiceOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ServiceOptionsTest extends \PHPUnit_Framework_TestCase
+class ServiceOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetGetTimeout()
     {

--- a/tests/Unit/Common/Internal/ServiceRestProxyTest.php
+++ b/tests/Unit/Common/Internal/ServiceRestProxyTest.php
@@ -44,7 +44,7 @@ use MicrosoftAzure\Storage\Common\Internal\Serialization\XmlSerializer;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ServiceRestProxyTest extends \PHPUnit_Framework_TestCase
+class ServiceRestProxyTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Common/Internal/StorageServiceSettingsTest.php
+++ b/tests/Unit/Common/Internal/StorageServiceSettingsTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class StorageServiceSettingsTest extends \PHPUnit_Framework_TestCase
+class StorageServiceSettingsTest extends \PHPUnit\Framework\TestCase
 {
     private $_accountName = 'mytestaccount';
     

--- a/tests/Unit/Common/Internal/UtilitiesTest.php
+++ b/tests/Unit/Common/Internal/UtilitiesTest.php
@@ -42,7 +42,7 @@ use GuzzleHttp\Psr7;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class UtilitiesTest extends \PHPUnit_Framework_TestCase
+class UtilitiesTest extends \PHPUnit\Framework\TestCase
 {
     public function testTryGetValue()
     {

--- a/tests/Unit/Common/Internal/ValidateTest.php
+++ b/tests/Unit/Common/Internal/ValidateTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ValidateTest extends \PHPUnit_Framework_TestCase
+class ValidateTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsArrayWithArray()
     {

--- a/tests/Unit/Common/Middlewares/MiddlewareStackTest.php
+++ b/tests/Unit/Common/Middlewares/MiddlewareStackTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Middlewares\MiddlewareStack;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class MiddlewareStackTest extends \PHPUnit_Framework_TestCase
+class MiddlewareStackTest extends \PHPUnit\Framework\TestCase
 {
     private $count;
 

--- a/tests/Unit/Common/Models/AccessPolicyTest.php
+++ b/tests/Unit/Common/Models/AccessPolicyTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-abstract class AccessPolicyTest extends \PHPUnit_Framework_TestCase
+abstract class AccessPolicyTest extends \PHPUnit\Framework\TestCase
 {
     abstract protected function createAccessPolicy();
     abstract protected function getResourceType();
@@ -46,54 +46,54 @@ abstract class AccessPolicyTest extends \PHPUnit_Framework_TestCase
         $accessPolicy = static::createAccessPolicy();
         $expected = new \DateTime('2009-09-28T08:49:37');
         $accessPolicy->setStart($expected);
-        
+
         // Test
         $actual = $accessPolicy->getStart();
-        
+
         // Assert
         $this->assertEquals($expected, $actual);
     }
-    
+
     public function testSetStart()
     {
         // Setup
         $accessPolicy = static::createAccessPolicy();
         $expected = new \DateTime('2009-09-28T08:49:37');
-        
+
         // Test
         $accessPolicy->setStart($expected);
-        
+
         // Assert
         $this->assertEquals($expected, $accessPolicy->getStart());
     }
-    
+
     public function testGetExpiry()
     {
         // Setup
         $accessPolicy = static::createAccessPolicy();
         $expected = new \DateTime('2009-09-28T08:49:37');
         $accessPolicy->setExpiry($expected);
-        
+
         // Test
         $actual = $accessPolicy->getExpiry();
-        
+
         // Assert
         $this->assertEquals($expected, $actual);
     }
-    
+
     public function testSetExpiry()
     {
         // Setup
         $accessPolicy = static::createAccessPolicy();
         $expected = new \DateTime('2009-09-28T08:49:37');
-        
+
         // Test
         $accessPolicy->setExpiry($expected);
-        
+
         // Assert
         $this->assertEquals($expected, $accessPolicy->getExpiry());
     }
-    
+
     public function testSetPermission()
     {
         // Setup
@@ -130,7 +130,7 @@ abstract class AccessPolicyTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue(false);
         }
     }
-    
+
     public function testToArray()
     {
         // Setup
@@ -143,10 +143,10 @@ abstract class AccessPolicyTest extends \PHPUnit_Framework_TestCase
         $accessPolicy->setPermission($permission);
         $accessPolicy->setStart($startDate);
         $accessPolicy->setExpiry($expiryDate);
-        
+
         // Test
         $actual = $accessPolicy->toArray();
-        
+
         // Assert
         $this->assertEquals($permission, $actual['Permission']);
         $this->assertEquals($start, urldecode($actual['Start']));

--- a/tests/Unit/Common/Models/CORSTest.php
+++ b/tests/Unit/Common/Models/CORSTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CORSTest extends \PHPUnit_Framework_TestCase
+class CORSTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateAndToArray()
     {

--- a/tests/Unit/Common/Models/GetServicePropertiesResultTest.php
+++ b/tests/Unit/Common/Models/GetServicePropertiesResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetServicePropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetServicePropertiesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Common/Models/GetServiceStatsResultTest.php
+++ b/tests/Unit/Common/Models/GetServiceStatsResultTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetServiceStatsResultTest extends \PHPUnit_Framework_TestCase
+class GetServiceStatsResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Common/Models/LoggingTest.php
+++ b/tests/Unit/Common/Models/LoggingTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class LoggingTest extends \PHPUnit_Framework_TestCase
+class LoggingTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Common/Models/MetricsTest.php
+++ b/tests/Unit/Common/Models/MetricsTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Models\RetentionPolicy;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class MetricsTest extends \PHPUnit_Framework_TestCase
+class MetricsTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Common/Models/RangeDiffTest.php
+++ b/tests/Unit/Common/Models/RangeDiffTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Common\Models\RangeDiff;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class RangeDiffTest extends \PHPUnit_Framework_TestCase
+class RangeDiffTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Common/Models/RangeTest.php
+++ b/tests/Unit/Common/Models/RangeTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Common\Models\Range;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class RangeTest extends \PHPUnit_Framework_TestCase
+class RangeTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Common/Models/RetentionPolicyTest.php
+++ b/tests/Unit/Common/Models/RetentionPolicyTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class RetentionPolicyTest extends \PHPUnit_Framework_TestCase
+class RetentionPolicyTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Common/Models/ServicePropertiesTest.php
+++ b/tests/Unit/Common/Models/ServicePropertiesTest.php
@@ -42,7 +42,7 @@ use MicrosoftAzure\Storage\Common\Internal\Serialization\XmlSerializer;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ServicePropertiesTest extends \PHPUnit_Framework_TestCase
+class ServicePropertiesTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/File/Models/DirectoryTest.php
+++ b/tests/Unit/File/Models/DirectoryTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class DirectoryTest extends \PHPUnit_Framework_TestCase
+class DirectoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/File/Models/FileTest.php
+++ b/tests/Unit/File/Models/FileTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends \PHPUnit\Framework\TestCase
 {
     /**
      *

--- a/tests/Unit/File/Models/GetDirectoryPropertiesResultTest.php
+++ b/tests/Unit/File/Models/GetDirectoryPropertiesResultTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetDirectoryPropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetDirectoryPropertiesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/File/Models/GetSharePropertiesResultTest.php
+++ b/tests/Unit/File/Models/GetSharePropertiesResultTest.php
@@ -40,7 +40,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetSharePropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetSharePropertiesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/File/Models/ListDirectoriesAndFilesResultTest.php
+++ b/tests/Unit/File/Models/ListDirectoriesAndFilesResultTest.php
@@ -40,7 +40,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListDirectoriesAndFilesResultTest extends \PHPUnit_Framework_TestCase
+class ListDirectoriesAndFilesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/File/Models/ListSharesResultTest.php
+++ b/tests/Unit/File/Models/ListSharesResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListSharesResultTest extends \PHPUnit_Framework_TestCase
+class ListSharesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateWithEmpty()
     {

--- a/tests/Unit/File/Models/SharePropertiesTest.php
+++ b/tests/Unit/File/Models/SharePropertiesTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class SharePropertiesTest extends \PHPUnit_Framework_TestCase
+class SharePropertiesTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/File/Models/ShareTest.php
+++ b/tests/Unit/File/Models/ShareTest.php
@@ -40,7 +40,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ShareTest extends \PHPUnit_Framework_TestCase
+class ShareTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Queue/Models/CreateMessageOptionsTest.php
+++ b/tests/Unit/Queue/Models/CreateMessageOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Queue\Models\CreateMessageOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateMessageOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateMessageOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetVisibilityTimeoutInSeconds()
     {

--- a/tests/Unit/Queue/Models/CreateQueueOptionsTest.php
+++ b/tests/Unit/Queue/Models/CreateQueueOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Queue\Models\CreateQueueOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateQueueOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateQueueOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetMetadata()
     {

--- a/tests/Unit/Queue/Models/GetQueueMetadataResultTest.php
+++ b/tests/Unit/Queue/Models/GetQueueMetadataResultTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Queue\Models\GetQueueMetadataResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetQueueMetadataResultTest extends \PHPUnit_Framework_TestCase
+class GetQueueMetadataResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Queue/Models/ListMessagesOptionsTest.php
+++ b/tests/Unit/Queue/Models/ListMessagesOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Queue\Models\ListMessagesOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListMessagesOptionsTest extends \PHPUnit_Framework_TestCase
+class ListMessagesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetVisibilityTimeoutInSeconds()
     {

--- a/tests/Unit/Queue/Models/ListMessagesResultTest.php
+++ b/tests/Unit/Queue/Models/ListMessagesResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListMessagesResultTest extends \PHPUnit_Framework_TestCase
+class ListMessagesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Queue/Models/ListQueuesOptionsTest.php
+++ b/tests/Unit/Queue/Models/ListQueuesOptionsTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListQueuesOptionsTest extends \PHPUnit_Framework_TestCase
+class ListQueuesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetPrefix()
     {

--- a/tests/Unit/Queue/Models/ListQueuesResultTest.php
+++ b/tests/Unit/Queue/Models/ListQueuesResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ListQueuesResultTest extends \PHPUnit_Framework_TestCase
+class ListQueuesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateWithEmpty()
     {

--- a/tests/Unit/Queue/Models/PeekMessagesOptionsTest.php
+++ b/tests/Unit/Queue/Models/PeekMessagesOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Queue\Models\PeekMessagesOptions;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class PeekMessagesOptionsTest extends \PHPUnit_Framework_TestCase
+class PeekMessagesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetNumberOfMessages()
     {

--- a/tests/Unit/Queue/Models/PeekMessagesResultTest.php
+++ b/tests/Unit/Queue/Models/PeekMessagesResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class PeekMessagesResultTest extends \PHPUnit_Framework_TestCase
+class PeekMessagesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Queue/Models/QueueACLTest.php
+++ b/tests/Unit/Queue/Models/QueueACLTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Serialization\XmlSerializer;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueueACLTest extends \PHPUnit_Framework_TestCase
+class QueueACLTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateEmpty()
     {

--- a/tests/Unit/Queue/Models/QueueMessageTest.php
+++ b/tests/Unit/Queue/Models/QueueMessageTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueueMessageTest extends \PHPUnit_Framework_TestCase
+class QueueMessageTest extends \PHPUnit\Framework\TestCase
 {
     public function testToXml()
     {

--- a/tests/Unit/Queue/Models/QueueTest.php
+++ b/tests/Unit/Queue/Models/QueueTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueueTest extends \PHPUnit_Framework_TestCase
+class QueueTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Queue/Models/UpdateMessageResultTest.php
+++ b/tests/Unit/Queue/Models/UpdateMessageResultTest.php
@@ -40,7 +40,7 @@ use MicrosoftAzure\Storage\Common\Internal\Resources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class UpdateMessageResultTest extends \PHPUnit_Framework_TestCase
+class UpdateMessageResultTest extends \PHPUnit\Framework\TestCase
 {
     /**
      *

--- a/tests/Unit/Table/Internal/Authentication/TableSharedKeyLiteAuthSchemeTest.php
+++ b/tests/Unit/Table/Internal/Authentication/TableSharedKeyLiteAuthSchemeTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license    https://github.com/azure/azure-storage-php/LICENSE
  * @link       https://github.com/azure/azure-storage-php
  */
-class TableSharedKeyLiteAuthSchemeTest extends \PHPUnit_Framework_TestCase
+class TableSharedKeyLiteAuthSchemeTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Table/Internal/JsonODataReaderWriterTest.php
+++ b/tests/Unit/Table/Internal/JsonODataReaderWriterTest.php
@@ -41,7 +41,7 @@ use MicrosoftAzure\Storage\Table\Models\Entity;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class JsonODataReaderWriterTest extends \PHPUnit_Framework_TestCase
+class JsonODataReaderWriterTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetTable()
     {

--- a/tests/Unit/Table/Models/BatchOperationParameterNameTest.php
+++ b/tests/Unit/Table/Models/BatchOperationParameterNameTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\BatchOperationParameterName;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BatchOperationParameterNameTest extends \PHPUnit_Framework_TestCase
+class BatchOperationParameterNameTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsValid()
     {

--- a/tests/Unit/Table/Models/BatchOperationTest.php
+++ b/tests/Unit/Table/Models/BatchOperationTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Table\Models\BatchOperationParameterName;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BatchOperationTest extends \PHPUnit_Framework_TestCase
+class BatchOperationTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetType()
     {

--- a/tests/Unit/Table/Models/BatchOperationTypeTest.php
+++ b/tests/Unit/Table/Models/BatchOperationTypeTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\BatchOperationType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BatchOperationTypeTest extends \PHPUnit_Framework_TestCase
+class BatchOperationTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsValid()
     {

--- a/tests/Unit/Table/Models/BatchOperationsTest.php
+++ b/tests/Unit/Table/Models/BatchOperationsTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Table\Models\Entity;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BatchOperationsTest extends \PHPUnit_Framework_TestCase
+class BatchOperationsTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstruct()
     {

--- a/tests/Unit/Table/Models/BatchResultTest.php
+++ b/tests/Unit/Table/Models/BatchResultTest.php
@@ -40,7 +40,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BatchResultTest extends \PHPUnit_Framework_TestCase
+class BatchResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Table/Models/DeleteEntityOptionsTest.php
+++ b/tests/Unit/Table/Models/DeleteEntityOptionsTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\ETag;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class DeleteEntityOptionsTest extends \PHPUnit_Framework_TestCase
+class DeleteEntityOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetETag()
     {

--- a/tests/Unit/Table/Models/EdmTypeTest.php
+++ b/tests/Unit/Table/Models/EdmTypeTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class EdmTypeTest extends \PHPUnit_Framework_TestCase
+class EdmTypeTest extends \PHPUnit\Framework\TestCase
 {
     public function testProcessTypeWithNull()
     {

--- a/tests/Unit/Table/Models/EntityTest.php
+++ b/tests/Unit/Table/Models/EntityTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class EntityTest extends \PHPUnit_Framework_TestCase
+class EntityTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetPropertyValue()
     {

--- a/tests/Unit/Table/Models/Filters/BinaryFilterTest.php
+++ b/tests/Unit/Table/Models/Filters/BinaryFilterTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\Filters\BinaryFilter;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class BinaryFilterTest extends \PHPUnit_Framework_TestCase
+class BinaryFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetOperator()
     {

--- a/tests/Unit/Table/Models/Filters/ConstantFilterTest.php
+++ b/tests/Unit/Table/Models/Filters/ConstantFilterTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Table\Models\EdmType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class ConstantFilterTest extends \PHPUnit_Framework_TestCase
+class ConstantFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetValue()
     {

--- a/tests/Unit/Table/Models/Filters/FilterTest.php
+++ b/tests/Unit/Table/Models/Filters/FilterTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Table\Models\EdmType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class FilterTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testApplyAnd()
     {

--- a/tests/Unit/Table/Models/Filters/PropertyNameFilterTest.php
+++ b/tests/Unit/Table/Models/Filters/PropertyNameFilterTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\Filters\PropertyNameFilter;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class PropertyNameFilterTest extends \PHPUnit_Framework_TestCase
+class PropertyNameFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetPropertyName()
     {

--- a/tests/Unit/Table/Models/Filters/QueryStringFilterTest.php
+++ b/tests/Unit/Table/Models/Filters/QueryStringFilterTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\Filters\QueryStringFilter;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueryStringFilterTest extends \PHPUnit_Framework_TestCase
+class QueryStringFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetQueryString()
     {

--- a/tests/Unit/Table/Models/Filters/UnaryFilterTest.php
+++ b/tests/Unit/Table/Models/Filters/UnaryFilterTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\Filters\UnaryFilter;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class UnaryFilterTest extends \PHPUnit_Framework_TestCase
+class UnaryFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetOperator()
     {

--- a/tests/Unit/Table/Models/GetEntityResultTest.php
+++ b/tests/Unit/Table/Models/GetEntityResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetEntityResultTest extends \PHPUnit_Framework_TestCase
+class GetEntityResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Table/Models/GetTableResultTest.php
+++ b/tests/Unit/Table/Models/GetTableResultTest.php
@@ -37,7 +37,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class GetTableResultTest extends \PHPUnit_Framework_TestCase
+class GetTableResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Table/Models/InsertEntityResultTest.php
+++ b/tests/Unit/Table/Models/InsertEntityResultTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Utilities;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class InsertEntityResultTest extends \PHPUnit_Framework_TestCase
+class InsertEntityResultTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testCreate()

--- a/tests/Unit/Table/Models/PropertyTest.php
+++ b/tests/Unit/Table/Models/PropertyTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\EdmType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class PropertyTest extends \PHPUnit_Framework_TestCase
+class PropertyTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetEdmType()
     {

--- a/tests/Unit/Table/Models/QueryEntitiesOptionsTest.php
+++ b/tests/Unit/Table/Models/QueryEntitiesOptionsTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Table\Models\EdmType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueryEntitiesOptionsTest extends \PHPUnit_Framework_TestCase
+class QueryEntitiesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetQuery()
     {

--- a/tests/Unit/Table/Models/QueryEntitiesResultTest.php
+++ b/tests/Unit/Table/Models/QueryEntitiesResultTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Table\Models\QueryEntitiesResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueryEntitiesResultTest extends \PHPUnit_Framework_TestCase
+class QueryEntitiesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Table/Models/QueryTablesOptionsTest.php
+++ b/tests/Unit/Table/Models/QueryTablesOptionsTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Table\Models\EdmType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueryTablesOptionsTest extends \PHPUnit_Framework_TestCase
+class QueryTablesOptionsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetNextTableName()
     {

--- a/tests/Unit/Table/Models/QueryTablesResultTest.php
+++ b/tests/Unit/Table/Models/QueryTablesResultTest.php
@@ -36,7 +36,7 @@ use MicrosoftAzure\Storage\Table\Models\QueryTablesResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueryTablesResultTest extends \PHPUnit_Framework_TestCase
+class QueryTablesResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/Unit/Table/Models/QueryTest.php
+++ b/tests/Unit/Table/Models/QueryTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Table\Models\EdmType;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class QueryTest extends \PHPUnit_Framework_TestCase
+class QueryTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetSelectFields()
     {

--- a/tests/Unit/Table/Models/TableACLTest.php
+++ b/tests/Unit/Table/Models/TableACLTest.php
@@ -39,7 +39,7 @@ use MicrosoftAzure\Storage\Common\Internal\Serialization\XmlSerializer;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class TableACLTest extends \PHPUnit_Framework_TestCase
+class TableACLTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreateEmpty()
     {

--- a/tests/Unit/Table/Models/UpdateEntityResultTest.php
+++ b/tests/Unit/Table/Models/UpdateEntityResultTest.php
@@ -35,7 +35,7 @@ use MicrosoftAzure\Storage\Table\Models\UpdateEntityResult;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class UpdateEntityResultTest extends \PHPUnit_Framework_TestCase
+class UpdateEntityResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {

--- a/tests/unit/Queue/Models/CreateMessageResultTest.php
+++ b/tests/unit/Queue/Models/CreateMessageResultTest.php
@@ -38,7 +38,7 @@ use MicrosoftAzure\Storage\Tests\Framework\TestResources;
  * @license   https://github.com/azure/azure-storage-php/LICENSE
  * @link      https://github.com/azure/azure-storage-php
  */
-class CreateMessageResultTest extends \PHPUnit_Framework_TestCase
+class CreateMessageResultTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreate()
     {


### PR DESCRIPTION
Use `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase` while extending our test cases. This will help us when migrating to `PHPUnit 6`, that no longer supports the old notation.