### PR TITLE
keep primary uri path when it exists

### DIFF
--- a/azure-storage-blob/src/Blob/BlobRestProxy.php
+++ b/azure-storage-blob/src/Blob/BlobRestProxy.php
@@ -384,11 +384,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
 
         if ($exPath != '') {
             //Remove the duplicated slash in the path.
-            if ($encodedBlob[0] == '/') {
-                $encodedBlob = $exPath . substr($encodedBlob, 1);
-            } else {
-                $encodedBlob = $exPath . $encodedBlob;
-            }
+            $encodedBlob = str_replace('//', '/', $exPath . $encodedBlob);
         }
 
         return (string) $uri->withPath($encodedBlob);

--- a/azure-storage-blob/src/Blob/BlobRestProxy.php
+++ b/azure-storage-blob/src/Blob/BlobRestProxy.php
@@ -379,8 +379,19 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
     private function getBlobUrl($container, $blob)
     {
         $encodedBlob = $this->createPath($container, $blob);
+        $uri = $this->getPsrPrimaryUri();
+        $exPath = $uri->getPath();
 
-        return (string)($this->getPsrPrimaryUri()->withPath($encodedBlob));
+        if ($exPath != '') {
+            //Remove the duplicated slash in the path.
+            if ($encodedBlob[0] == '/') {
+                $encodedBlob = $exPath . substr($encodedBlob, 1);
+            } else {
+                $encodedBlob = $exPath . $encodedBlob;
+            }
+        }
+
+        return (string) $uri->withPath($encodedBlob);
     }
       
     /**


### PR DESCRIPTION
When constructing the blob URL and testing the SDK with the [emulated storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator) the **AccountName** is in the primary URI path. And this base path gets dropped when retrieving the blob URL. Now it prepends the primary URI path to the blob path before building the final URL.