### PR TITLE
Fix generateCanonicalResource substr

### DIFF
--- a/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
+++ b/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
@@ -324,7 +324,7 @@ class SharedAccessSignatureHelper
         );
         $serviceName = $serviceMap[$service];
         if (Utilities::startsWith($resource, '/')) {
-            $resource = substr($resource, 1, strlen($resource) - 1);
+            $resource = substr($resource, 1);
         }
         return sprintf('/%s/%s/%s', $serviceName, $accountName, $resource);
     }

--- a/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
+++ b/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
@@ -324,7 +324,7 @@ class SharedAccessSignatureHelper
         );
         $serviceName = $serviceMap[$service];
         if (Utilities::startsWith($resource, '/')) {
-            $resource = substr(1, strlen($resource) - 1);
+            $resource = substr($resource, 1, strlen($resource) - 1);
         }
         return sprintf('/%s/%s/%s', $serviceName, $accountName, $resource);
     }

--- a/tests/Unit/Common/SharedAccessSignatureHelperTest.php
+++ b/tests/Unit/Common/SharedAccessSignatureHelperTest.php
@@ -260,4 +260,35 @@ class SharedAccessSignatureHelperTest extends ReflectionTestBase
             }
         }
     }
+
+    public function testGenerateCanonicalResource()
+    {
+        // Setup
+        $sasHelper = $this->testConstruct();
+        $validateAndSanitizeSignedService = self::getMethod('generateCanonicalResource', $sasHelper);
+        
+        $resourceNames = array();
+        $resourceNames[] = "filename";
+        $resourceNames[] = "/filename";
+        $resourceNames[] = "/filename/";
+        $resourceNames[] = "folder/filename";
+        $resourceNames[] = "/folder/filename";
+        $resourceNames[] = "/folder/filename/";
+
+        $expected = array();
+        $expected[] = "/blob/test/filename";
+        $expected[] = "/blob/test/filename";
+        $expected[] = "/blob/test/filename/";
+        $expected[] = "/blob/test/folder/filename";
+        $expected[] = "/blob/test/folder/filename";
+        $expected[] = "/blob/test/folder/filename/";
+
+        for ($i = 0; $i < count($resourceNames); $i++) {
+            // Test
+            $actual = $validateAndSanitizeSignedService->invokeArgs($sasHelper, array('test', Resources::RESOURCE_TYPE_BLOB, $resourceNames[$i]));
+
+            // Assert
+            $this->assertEquals($expected[$i], $actual);
+        }
+    }
 }


### PR DESCRIPTION
Adds missing $resource parameter to substr to fix generateCanonicalResource returning an empty string if $resource starts with /