### PR TITLE
Set the getBlobUrl() method visibility to public

### DIFF
--- a/azure-storage-blob/src/Blob/BlobRestProxy.php
+++ b/azure-storage-blob/src/Blob/BlobRestProxy.php
@@ -376,7 +376,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
      *
      * @return string
      */
-    private function getBlobUrl($container, $blob)
+    public function getBlobUrl($container, $blob)
     {
         $encodedBlob = $this->createPath($container, $blob);
         $uri = $this->getPsrPrimaryUri();


### PR DESCRIPTION
Once uploaded, in order to share/expose a "public" blob, set the visibility of the BlobRestProxy::getBlobUrl() method to public to get the url of a given blob.

#144