### PR TITLE
Optional middleware retry on connection failures

### DIFF
--- a/azure-storage-common/src/Common/Middlewares/RetryMiddlewareFactory.php
+++ b/azure-storage-common/src/Common/Middlewares/RetryMiddlewareFactory.php
@@ -26,6 +26,7 @@ namespace MicrosoftAzure\Storage\Common\Middlewares;
 
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Common\Internal\Validate;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 
 /**
@@ -68,6 +69,7 @@ class RetryMiddlewareFactory
      *                                     Possible value can be
      *                                     self::LINEAR_INTERVAL_ACCUMULATION or
      *                                     self::EXPONENTIAL_INTERVAL_ACCUMULATION
+     * @param  bool   $retryConnect        Whether to retry on connection failures.
      * @return RetryMiddleware             A RetryMiddleware object that contains
      *                                     the logic of how the request should be
      *                                     handled after a response.
@@ -76,7 +78,8 @@ class RetryMiddlewareFactory
         $type = self::GENERAL_RETRY_TYPE,
         $numberOfRetries = Resources::DEFAULT_NUMBER_OF_RETRIES,
         $interval = Resources::DEAFULT_RETRY_INTERVAL,
-        $accumulationMethod = self::LINEAR_INTERVAL_ACCUMULATION
+        $accumulationMethod = self::LINEAR_INTERVAL_ACCUMULATION,
+        $retryConnect = false
     ) {
         //Validate the input parameters
         //type
@@ -113,6 +116,8 @@ class RetryMiddlewareFactory
                 'accumulationMethod'
             )
         );
+        //retryConnect
+        Validate::isBoolean($retryConnect);
 
         //Get the interval calculator according to the type of the
         //accumulation method.
@@ -123,7 +128,7 @@ class RetryMiddlewareFactory
 
         //Get the retry decider according to the type of the retry and
         //the number of retries.
-        $retryDecider = self::createRetryDecider($type, $numberOfRetries);
+        $retryDecider = self::createRetryDecider($type, $numberOfRetries, $retryConnect);
 
         //construct the retry middle ware.
         return new RetryMiddleware($intervalCalculator, $retryDecider);
@@ -134,13 +139,14 @@ class RetryMiddlewareFactory
      * that accepts the number of retries, the request, the response and the
      * exception, and return the decision for a retry.
      *
-     * @param  string $type       The type of the retry handler.
-     * @param  int    $maxRetries The maximum number of retries to be done.
+     * @param  string $type         The type of the retry handler.
+     * @param  int    $maxRetries   The maximum number of retries to be done.
+     * @param  bool   $retryConnect Whether to retry on connection failures.
      *
      * @return callable     The callable that will return if the request should
      *                      be retried.
      */
-    protected static function createRetryDecider($type, $maxRetries)
+    protected static function createRetryDecider($type, $maxRetries, $retryConnect)
     {
         return function (
             $retries,
@@ -150,17 +156,19 @@ class RetryMiddlewareFactory
             $isSecondary = false
         ) use (
             $type,
-            $maxRetries
+            $maxRetries,
+            $retryConnect
         ) {
             //Exceeds the retry limit. No retry.
             if ($retries >= $maxRetries) {
                 return false;
             }
 
-            //Not retriable error, won't retry.
             if (!$response) {
                 if (!$exception || !($exception instanceof RequestException)) {
                     return false;
+                } elseif ($exception instanceof ConnectException) {
+                    return $retryConnect;
                 } else {
                     $response = $exception->getResponse();
                 }

--- a/tests/Unit/Common/Middlewares/RetryMiddlewareFactoryTest.php
+++ b/tests/Unit/Common/Middlewares/RetryMiddlewareFactoryTest.php
@@ -27,6 +27,7 @@ namespace MicrosoftAzure\Storage\Tests\Unit\Common\Middlewares;
 use MicrosoftAzure\Storage\Common\Middlewares\RetryMiddlewareFactory;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
 use MicrosoftAzure\Storage\Tests\Framework\ReflectionTestBase;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Request;
 
@@ -93,7 +94,7 @@ class RetryMiddlewareFactoryTest extends ReflectionTestBase
         $createRetryDecider = self::getMethod('createRetryDecider', new RetryMiddlewareFactory());
         $generalDecider = $createRetryDecider->invokeArgs(
             null,
-            array(RetryMiddlewareFactory::GENERAL_RETRY_TYPE, 3)
+            array(RetryMiddlewareFactory::GENERAL_RETRY_TYPE, 3, false)
         );
         $request = new Request('PUT', '127.0.0.1');
         $retryResult_1 = $generalDecider(1, $request, new Response(408));//retry
@@ -102,6 +103,7 @@ class RetryMiddlewareFactoryTest extends ReflectionTestBase
         $retryResult_4 = $generalDecider(1, $request, new Response(200));//no-retry
         $retryResult_5 = $generalDecider(1, $request, new Response(503));//retry
         $retryResult_6 = $generalDecider(4, $request, new Response(503));//no-retry
+        $retryResult_7 = $generalDecider(1, $request, null, new ConnectException('message', $request));//no-retry
 
         //assert
         $this->assertTrue($retryResult_1);
@@ -110,6 +112,19 @@ class RetryMiddlewareFactoryTest extends ReflectionTestBase
         $this->assertFalse($retryResult_4);
         $this->assertTrue($retryResult_5);
         $this->assertFalse($retryResult_6);
+        $this->assertFalse($retryResult_7);
+    }
+
+    public function testCreateRetryDeciderWithConnectionRetries()
+    {
+        $createRetryDecider = self::getMethod('createRetryDecider', new RetryMiddlewareFactory());
+        $generalDecider = $createRetryDecider->invokeArgs(
+            null,
+            array(RetryMiddlewareFactory::GENERAL_RETRY_TYPE, 3, true)
+        );
+        $request = new Request('PUT', '127.0.0.1');
+        $retryResult = $generalDecider(1, $request, null, new ConnectException('message', $request));
+        $this->assertTrue($retryResult);
     }
 
     public function testCreateLinearDelayCalculator()


### PR DESCRIPTION
This modifies the retry decider to (optionally) retry also on connection failures.

Fix #147