### PR TITLE
Skipping $signedIP because it was causing AuthenticationFailed

### DIFF
--- a/azure-storage-blob/src/Blob/BlobSharedAccessSignatureHelper.php
+++ b/azure-storage-blob/src/Blob/BlobSharedAccessSignatureHelper.php
@@ -90,7 +90,7 @@ class BlobSharedAccessSignatureHelper extends SharedAccessSignatureHelper
         $signedPermissions,
         $signedExpiry,
         $signedStart = "",
-        $signedIP = "",
+        $signedIP = null,
         $signedProtocol = "",
         $signedIdentifier = "",
         $cacheControl = "",
@@ -203,7 +203,9 @@ class BlobSharedAccessSignatureHelper extends SharedAccessSignatureHelper
         $sas .= $buildOptQueryStr($signedStart, '&st=');
         $sas .= '&se=' . $signedExpiry;
         $sas .= '&sp=' . $signedPermissions;
-        $sas .= $buildOptQueryStr($signedIP, '&sip=');
+        if($signedIP){
+            $sas .= $buildOptQueryStr($signedIP, '&sip=');
+        }
         $sas .= $buildOptQueryStr($signedProtocol, '&spr=');
         $sas .= $buildOptQueryStr($signedIdentifier, '&si=');
         $sas .= '&sig=' . $sig;


### PR DESCRIPTION
When not setting a signedIP it as causing an error on the generations of the SAS link
Just skiping the signedIP if not set (null)
<Error>
<Code>AuthenticationFailed</Code>
<Message>
Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature. RequestId:2e18f54d-901e-003e-7f66-8dbc1d000000 Time:2018-12-06T13:22:00.5943333Z
</Message>
<AuthenticationErrorDetail>sip is optional but cannot be empty</AuthenticationErrorDetail>
</Error>