### PR TITLE
Resource is an internal type not a class

### DIFF
--- a/azure-storage-blob/src/Blob/Models/GetBlobResult.php
+++ b/azure-storage-blob/src/Blob/Models/GetBlobResult.php
@@ -113,7 +113,7 @@ class GetBlobResult
     /**
      * Gets blob contentStream.
      *
-     * @return \resource
+     * @return resource
      */
     public function getContentStream()
     {
@@ -123,7 +123,7 @@ class GetBlobResult
     /**
      * Sets blob contentStream.
      *
-     * @param \resource $contentStream The stream handle.
+     * @param resource $contentStream The stream handle.
      *
      * @return void
      */

--- a/azure-storage-file/src/File/Models/GetFileResult.php
+++ b/azure-storage-file/src/File/Models/GetFileResult.php
@@ -113,7 +113,7 @@ class GetFileResult
     /**
      * Gets file contentStream.
      *
-     * @return \resource
+     * @return resource
      */
     public function getContentStream()
     {
@@ -123,7 +123,7 @@ class GetFileResult
     /**
      * Sets file contentStream.
      *
-     * @param \resource $contentStream The stream handle.
+     * @param resource $contentStream The stream handle.
      *
      * @return void
      */


### PR DESCRIPTION
Hi,

`resource` returned from or passed to stream-related methods is an internal "type" and not a class so it should not be namespaced. Static analysis, PHPStan for example, throws warnings when it is. This PR removes the root namespace.

Thanks!