### PR TITLE
setQueueMessages accepts array, not int

### DIFF
--- a/azure-storage-queue/src/Queue/Models/ListMessagesResult.php
+++ b/azure-storage-queue/src/Queue/Models/ListMessagesResult.php
@@ -80,13 +80,13 @@ class ListMessagesResult
     /**
      * Sets queueMessages field.
      *
-     * @param integer $queueMessages value to use.
+     * @param array $queueMessages value to use.
      *
      * @internal
      *
      * @return void
      */
-    protected function setQueueMessages($queueMessages)
+    protected function setQueueMessages(array $queueMessages)
     {
         $this->_queueMessages = array();
 


### PR DESCRIPTION
`ListMessagesResult::setQueueMessages()` is used here for example (only here actually):

https://github.com/Azure/azure-storage-php/blob/552d55f27c237d031dad614b4563dedb1095f6c6/azure-storage-queue/src/Queue/Models/ListMessagesResult.php#L55-L65

Thanks!