### PR TITLE
Add support for EndpointSuffix in connection strings

### DIFF
--- a/azure-storage-common/src/Common/Internal/Resources.php
+++ b/azure-storage-common/src/Common/Internal/Resources.php
@@ -51,12 +51,18 @@ class Resources
     const TABLE_ENDPOINT_NAME = 'TableEndpoint';
     const FILE_ENDPOINT_NAME = 'FileEndpoint';
     const SHARED_ACCESS_SIGNATURE_NAME = 'SharedAccessSignature';
+    const ENDPOINT_SUFFIX_NAME = 'EndpointSuffix';
+    const DEFAULT_ENDPOINT_SUFFIX = 'core.windows.net';
     const DEV_STORE_NAME = 'devstoreaccount1';
     const DEV_STORE_KEY = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==';
     const BLOB_BASE_DNS_NAME = 'blob.core.windows.net';
+    const BLOB_DNS_PREFIX = 'blob.';
     const QUEUE_BASE_DNS_NAME = 'queue.core.windows.net';
+    const QUEUE_DNS_PREFIX = 'queue.';
     const TABLE_BASE_DNS_NAME = 'table.core.windows.net';
+    const TABLE_DNS_PREFIX = 'table.';
     const FILE_BASE_DNS_NAME = 'file.core.windows.net';
+    const FILE_DNS_PREFIX = 'file.';
     const DEV_STORE_CONNECTION_STRING = 'BlobEndpoint=127.0.0.1:10000;QueueEndpoint=127.0.0.1:10001;TableEndpoint=127.0.0.1:10002;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==';
     const SUBSCRIPTION_ID_NAME = 'SubscriptionID';
     const CERTIFICATE_PATH_NAME = 'CertificatePath';
@@ -83,6 +89,7 @@ class Resources
     const INVALID_CREATE_SERVICE_OPTIONS_MSG = 'Must provide valid location or affinity group.';
     const INVALID_UPDATE_SERVICE_OPTIONS_MSG = 'Must provide either description or label.';
     const INVALID_CONFIG_MSG = 'Config object must be of type Configuration';
+    const INVALID_CONFIG_HOSTNAME = "The provided hostname '%s' is invalid.";
     const INVALID_CONFIG_URI = "The provided URI '%s' is invalid. It has to pass the check 'filter_var(<user_uri>, FILTER_VALIDATE_URL)'.";
     const INVALID_CONFIG_VALUE = "The provided config value '%s' does not belong to the valid values subset:\n%s";
     const INVALID_ACCOUNT_KEY_FORMAT = "The provided account key '%s' is not a valid base64 string. It has to pass the check 'base64_decode(<user_account_key>, true)'.";

--- a/azure-storage-common/src/Common/Internal/Validate.php
+++ b/azure-storage-common/src/Common/Internal/Validate.php
@@ -271,7 +271,12 @@ class Validate
      */
     public static function isValidHostname($hostname)
     {
-        $isValid = filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+        if (defined('FILTER_VALIDATE_DOMAIN')) {
+            $isValid = filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+        } else {
+            // (less accurate) fallback for PHP < 7.0
+            $isValid = preg_match('/^[a-z0-9_-]+(\.[a-z0-9_-]+)*$/i', $hostname);
+        }
 
         if ($isValid) {
             return true;

--- a/azure-storage-common/src/Common/Internal/Validate.php
+++ b/azure-storage-common/src/Common/Internal/Validate.php
@@ -249,6 +249,40 @@ class Validate
     }
 
     /**
+     * Creates an anonymous function that checks if the given hostname is valid or not.
+     *
+     * @return callable
+     */
+    public static function getIsValidHostname()
+    {
+        return function ($hostname) {
+            return Validate::isValidHostname($hostname);
+        };
+    }
+
+    /**
+     * Throws an exception if the string is not of a valid hostname.
+     *
+     * @param string $hostname String to check.
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return boolean
+     */
+    public static function isValidHostname($hostname)
+    {
+        $isValid = filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+
+        if ($isValid) {
+            return true;
+        } else {
+            throw new \RuntimeException(
+                sprintf(Resources::INVALID_CONFIG_HOSTNAME, $hostname)
+            );
+        }
+    }
+
+    /**
      * Creates a anonymous function that check if the given uri is valid or not.
      *
      * @return callable

--- a/tests/Unit/Common/Internal/StorageServiceSettingsTest.php
+++ b/tests/Unit/Common/Internal/StorageServiceSettingsTest.php
@@ -454,6 +454,24 @@ class StorageServiceSettingsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedTableEndpoint, $actual->getTableEndpointUri());
     }
 
+    public function testCreateFromConnectionStringWithEndpointSuffixSpecfied()
+    {
+        // Setup
+        $protocol = 'https';
+        $expectedName = $this->_accountName;
+        $expectedKey = TestResources::KEY4;
+        $expectedBlobEndpoint = "$protocol://$expectedName.blob.core.chinacloudapi.cn";
+        $expectedFileSecondaryEndpoint = "$protocol://$expectedName-secondary.file.core.chinacloudapi.cn";
+        $connectionString  = "DefaultEndpointsProtocol=$protocol;AccountName=$expectedName;AccountKey=$expectedKey;EndpointSuffix=core.chinacloudapi.cn";
+
+        // Test
+        $actual = StorageServiceSettings::createFromConnectionString($connectionString);
+
+        // Assert
+        $this->assertEquals($expectedBlobEndpoint, $actual->getBlobEndpointUri());
+        $this->assertEquals($expectedFileSecondaryEndpoint, $actual->getFileSecondaryEndpointUri());
+    }
+
     public function testCreateFromConnectionStringMissingServicesEndpointsFail()
     {
         // Setup

--- a/tests/Unit/Common/Internal/ValidateTest.php
+++ b/tests/Unit/Common/Internal/ValidateTest.php
@@ -249,13 +249,58 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
         // Assert
     }
 
+    public function testGetValidateHostname()
+    {
+        // Test
+        $function = Validate::getIsValidHostname();
+
+        // Assert
+        $this->assertInternalType('callable', $function);
+    }
+
+    public function testIsValidHostnamePass()
+    {
+        // Setup
+        $value = 'test.com';
+
+        // Test
+        $result = Validate::isValidHostname($value);
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    public function testIsValidHostnameNull()
+    {
+        // Setup
+        $this->setExpectedException(get_class(new \RuntimeException('')));
+        $value = null;
+
+        // Test
+        $result = Validate::isValidHostname($value);
+
+        // Assert
+    }
+
+    public function testIsValidHostnameInvalid()
+    {
+        // Setup
+        $this->setExpectedException(get_class(new \RuntimeException('')));
+        $value = '.test';
+
+        // Test
+        $result = Validate::isValidHostname($value);
+
+        // Assert
+    }
+
     public function testGetValidateUri()
     {
         // Test
         $function = Validate::getIsValidUri();
 
         // Assert
-        $this->assertInternalType('object', $function);
+        $this->assertInternalType('callable', $function);
     }
 
     public function testIsValidUriPass()


### PR DESCRIPTION
This PR adds support for EndpointSuffix in connection strings. The patch was tested against a real storage account and should introduce no BC breaks. In the future, `Resources::*_BASE_DNS_NAME` could be deprecated and subsequently removed.

Fixes #162 