### PR TITLE
Correct docblock types

### DIFF
--- a/azure-storage-blob/src/Blob/Internal/IBlob.php
+++ b/azure-storage-blob/src/Blob/Internal/IBlob.php
@@ -492,7 +492,7 @@ interface IBlob
     * @param string                            $content   content of the blob
     * @param BlobModels\CreateBlockBlobOptions $options   optional parameters
     *
-    * @return BlobModels\CopyBlobResult
+    * @return BlobModels\PutBlobResult
     *
     * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
     */

--- a/azure-storage-blob/src/Blob/Internal/IBlob.php
+++ b/azure-storage-blob/src/Blob/Internal/IBlob.php
@@ -407,7 +407,7 @@ interface IBlob
     * a 512-byte boundary.
     * @param BlobModels\CreatePageBlobOptions $options   optional parameters
     *
-    * @return BlobModels\CopyBlobResult
+    * @return BlobModels\PutBlobResult
     *
     * @see http://msdn.microsoft.com/en-us/library/windowsazure/dd179451.aspx
     */

--- a/azure-storage-queue/src/Queue/Internal/IQueue.php
+++ b/azure-storage-queue/src/Queue/Internal/IQueue.php
@@ -27,7 +27,7 @@ namespace MicrosoftAzure\Storage\Queue\Internal;
 use MicrosoftAzure\Storage\Queue\Models as QueueModels;
 use MicrosoftAzure\Storage\Common\Models\ServiceProperties;
 use MicrosoftAzure\Storage\Common\Models\ServiceOptions;
-use MicrosoftAzure\Storage\Common\Models\GetServiceStats;
+use MicrosoftAzure\Storage\Common\Models\GetServiceStatsResult;
 
 /**
  * This interface has all REST APIs provided by Windows Azure for queue service

--- a/azure-storage-table/src/Table/Internal/ITable.php
+++ b/azure-storage-table/src/Table/Internal/ITable.php
@@ -27,7 +27,7 @@ namespace MicrosoftAzure\Storage\Table\Internal;
 use MicrosoftAzure\Storage\Table\Models as TableModels;
 use MicrosoftAzure\Storage\Common\Models\ServiceProperties;
 use MicrosoftAzure\Storage\Common\Models\ServiceOptions;
-use MicrosoftAzure\Storage\Common\Models\GetServiceStats;
+use MicrosoftAzure\Storage\Common\Models\GetServiceStatsResult;
 
 /**
  * This interface has all REST APIs provided by Windows Azure for Table service.

--- a/azure-storage-table/src/Table/Internal/ITable.php
+++ b/azure-storage-table/src/Table/Internal/ITable.php
@@ -255,7 +255,7 @@ interface ITable
      *
      * @param string                                                   $table   The name of
      * the table.
-     * @param Models\QueryEntitiesOptions|string|Models\Filters\Filter $options Coule be
+     * @param TableModels\QueryEntitiesOptions|string|Models\Filters\Filter $options Coule be
      * optional parameters, query string or filter to apply.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface

--- a/azure-storage-table/src/Table/Internal/ITable.php
+++ b/azure-storage-table/src/Table/Internal/ITable.php
@@ -255,7 +255,7 @@ interface ITable
      *
      * @param string                                                   $table   The name of
      * the table.
-     * @param TableModels\QueryEntitiesOptions|string|Models\Filters\Filter $options Coule be
+     * @param TableModels\QueryEntitiesOptions|string|TableModels\Filters\Filter $options Coule be
      * optional parameters, query string or filter to apply.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface

--- a/azure-storage-table/src/Table/Internal/ITable.php
+++ b/azure-storage-table/src/Table/Internal/ITable.php
@@ -141,7 +141,7 @@ interface ITable
     /**
      * Creates promise to query the tables in the given storage account.
      *
-     * @param TableModels\QueryTablesOptions|string|Models\Filters\Filter $options
+     * @param TableModels\QueryTablesOptions|string|TableModels\Filters\Filter $options
      * Could be optional parameters, table prefix or filter to apply.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface


### PR DESCRIPTION
This fixes wrong types in interfaces, found by PHPStan.

All the commits might be squashed to just one when merging.

Thanks!