### PR TITLE
Fixed up verify override

### DIFF
--- a/azure-storage-common/src/Common/Internal/ServiceRestProxy.php
+++ b/azure-storage-common/src/Common/Internal/ServiceRestProxy.php
@@ -108,7 +108,7 @@ class ServiceRestProxy extends RestProxy
             $options['proxy'] = $proxy;
         }
 
-        if (!empty($options['verify'])) {
+        if (isset($options['verify'])) {
             $verify = $options['verify'];
         }
 


### PR DESCRIPTION
#126 added the ability to override Guzzle's SSL verify flag so users can supply their own CA certs file.  Only problem is if you disable SSL verification by passing `'verify' => false` it will be ignored as `false` in `empty()` is an empty value.  Changing to `isset()` overrides Guzzle's verification setting, along with passing all responsibility of verifying that value to Guzzle.