### PR TITLE
Fixed `createFileFromContent` authentication failure when uploading some local file stream types. Fixed #200

### DIFF
--- a/azure-storage-file/ChangeLog.md
+++ b/azure-storage-file/ChangeLog.md
@@ -1,3 +1,6 @@
+2020.01 - version 1.2.2
+* Fixed `createFileFromContent` authentication failure when uploading some local file stream types. 
+
 2019.04 - version 1.2.1
 * Resolved some issues on Linux platform.
 

--- a/azure-storage-file/src/File/FileRestProxy.php
+++ b/azure-storage-file/src/File/FileRestProxy.php
@@ -410,6 +410,9 @@ class FileRestProxy extends ServiceRestProxy implements IFile
                 $size
             );
 
+            // Stop Guzzle adding content-type header which may block SharedKey authentication
+            $headers[Resources::CONTENT_TYPE] = Resources::EMPTY_STRING;
+
             if ($useTransactionalMD5) {
                 $contentMD5 = base64_encode(md5($chunkContent, true));
                 $this->addOptionalHeader(
@@ -2273,6 +2276,9 @@ class FileRestProxy extends ServiceRestProxy implements IFile
             Resources::QP_COMP,
             'range'
         );
+
+        // Stop Guzzle adding content-type header which may block SharedKey authentication
+        $headers[Resources::CONTENT_TYPE] = Resources::EMPTY_STRING;
 
         return $this->sendAsync(
             $method,


### PR DESCRIPTION
Notice that, did not add test case because the copyright issue to attach .mp3 or .avi files into project. 
Manually targeting tests fine.