### PR TITLE
Accept DateTimeImmutable as EdmType input

### DIFF
--- a/azure-storage-common/src/Common/Internal/Validate.php
+++ b/azure-storage-common/src/Common/Internal/Validate.php
@@ -180,7 +180,7 @@ class Validate
     }
 
     /**
-     * Throws exception if the provided $date is not of type \DateTime
+     * Throws exception if the provided $date doesn't implement \DateTimeInterface
      *
      * @param mixed $date variable to check against.
      *
@@ -190,8 +190,8 @@ class Validate
      */
     public static function isDate($date)
     {
-        if (gettype($date) != 'object' || get_class($date) != 'DateTime') {
-            throw new InvalidArgumentTypeException('DateTime');
+        if (gettype($date) != 'object' || !($date instanceof \DateTimeInterface)) {
+            throw new InvalidArgumentTypeException('DateTimeInterface');
         }
     }
 

--- a/azure-storage-table/src/Table/Models/EdmType.php
+++ b/azure-storage-table/src/Table/Models/EdmType.php
@@ -142,8 +142,8 @@ class EdmType
                 return is_int($value) || is_string($value);
 
             case EdmType::DATETIME:
-                $condition = 'instanceof \DateTime';
-                return $value instanceof \DateTime;
+                $condition = 'instanceof \DateTimeInterface';
+                return $value instanceof \DateTimeInterface;
 
             case EdmType::BOOLEAN:
                 $condition = 'is_bool';

--- a/tests/Unit/Common/Internal/ValidateTest.php
+++ b/tests/Unit/Common/Internal/ValidateTest.php
@@ -100,9 +100,17 @@ class ValidateTest extends \PHPUnit\Framework\TestCase
         Validate::isTrue(false, Resources::EMPTY_STRING);
     }
 
-    public function testIsDateWithDate()
+    public function testIsDateWithDateTime()
     {
         $date = Utilities::rfc1123ToDateTime('Fri, 09 Oct 2009 21:04:30 GMT');
+        Validate::isDate($date);
+
+        $this->assertTrue(true);
+    }
+
+    public function testIsDateWithDateTimeImmutable()
+    {
+        $date = new \DateTimeImmutable();
         Validate::isDate($date);
 
         $this->assertTrue(true);

--- a/tests/Unit/Table/Models/EdmTypeTest.php
+++ b/tests/Unit/Table/Models/EdmTypeTest.php
@@ -198,11 +198,25 @@ class EdmTypeTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testValidateEdmValueWithDate()
+    public function testValidateEdmValueWithDateTime()
     {
         // Setup
         $type = EdmType::DATETIME;
         $value = new \DateTime();
+        $expected = true;
+
+        // Test
+        $actual = EdmType::validateEdmValue($type, $value);
+
+        // Assert
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testValidateEdmValueWithDateTimeImmutable()
+    {
+        // Setup
+        $type = EdmType::DATETIME;
+        $value = new \DateTimeImmutable();
         $expected = true;
 
         // Test


### PR DESCRIPTION
This allows to do things like

```php
$entity->addProperty('end', EdmType::DATETIME, new \DateTimeImmutable());
```

`DateTimeImmutable` is sometimes coming from other libs and converting it to mutable with `DateTime::createFromImmutable()` feels like unnecessary work.

Both `DateTimeImmutable` and `DateTimeInterface` appeared in PHP 5.5.0, the SDK targets PHP 5.6.0+.

Thanks!