### PR TITLE
Retry auth failures with middleware

### DIFF
--- a/azure-storage-common/src/Common/Middlewares/RetryMiddlewareFactory.php
+++ b/azure-storage-common/src/Common/Middlewares/RetryMiddlewareFactory.php
@@ -237,11 +237,13 @@ class RetryMiddlewareFactory
      * Decide if the given status code indicate the request should be retried.
      * This is for append blob.
      *
-     * @param  int $statusCode status code of the previous request.
+     * @param  int  $statusCode  Status code of the previous request.
+     * @param  bool $isSecondary Whether the request is sent to secondary endpoint.
+     * @param  bool $retryAuth   Whether to retry on authentication failures.
      *
      * @return bool            true if the request should be retried.
      */
-    protected static function appendBlobRetryDecider($statusCode)
+    protected static function appendBlobRetryDecider($statusCode, $isSecondary, $retryAuth)
     {
         //The retry logic is different for append blob.
         //First it will need to record the former status code if it is
@@ -249,7 +251,7 @@ class RetryMiddlewareFactory
         //needs to be retried. Currently this is not implemented so will
         //only adapt to the general retry decider.
         //TODO: add logic for append blob's retry when implemented.
-        $retry = self::generalRetryDecider($statusCode);
+        $retry = self::generalRetryDecider($statusCode, $isSecondary, $retryAuth);
         return $retry;
     }
 

--- a/tests/Unit/Common/Middlewares/RetryMiddlewareFactoryTest.php
+++ b/tests/Unit/Common/Middlewares/RetryMiddlewareFactoryTest.php
@@ -94,7 +94,7 @@ class RetryMiddlewareFactoryTest extends ReflectionTestBase
         $createRetryDecider = self::getMethod('createRetryDecider', new RetryMiddlewareFactory());
         $generalDecider = $createRetryDecider->invokeArgs(
             null,
-            array(RetryMiddlewareFactory::GENERAL_RETRY_TYPE, 3, false)
+            array(RetryMiddlewareFactory::GENERAL_RETRY_TYPE, 3, false, false)
         );
         $request = new Request('PUT', '127.0.0.1');
         $retryResult_1 = $generalDecider(1, $request, new Response(408));//retry
@@ -104,6 +104,7 @@ class RetryMiddlewareFactoryTest extends ReflectionTestBase
         $retryResult_5 = $generalDecider(1, $request, new Response(503));//retry
         $retryResult_6 = $generalDecider(4, $request, new Response(503));//no-retry
         $retryResult_7 = $generalDecider(1, $request, null, new ConnectException('message', $request));//no-retry
+        $retryResult_8 = $generalDecider(1, $request, new Response(403));//no-retry
 
         //assert
         $this->assertTrue($retryResult_1);
@@ -113,6 +114,7 @@ class RetryMiddlewareFactoryTest extends ReflectionTestBase
         $this->assertTrue($retryResult_5);
         $this->assertFalse($retryResult_6);
         $this->assertFalse($retryResult_7);
+        $this->assertFalse($retryResult_8);
     }
 
     public function testCreateRetryDeciderWithConnectionRetries()
@@ -120,10 +122,22 @@ class RetryMiddlewareFactoryTest extends ReflectionTestBase
         $createRetryDecider = self::getMethod('createRetryDecider', new RetryMiddlewareFactory());
         $generalDecider = $createRetryDecider->invokeArgs(
             null,
-            array(RetryMiddlewareFactory::GENERAL_RETRY_TYPE, 3, true)
+            array(RetryMiddlewareFactory::GENERAL_RETRY_TYPE, 3, true, false)
         );
         $request = new Request('PUT', '127.0.0.1');
         $retryResult = $generalDecider(1, $request, null, new ConnectException('message', $request));
+        $this->assertTrue($retryResult);
+    }
+
+    public function testCreateRetryDeciderWithAuthRetries()
+    {
+        $createRetryDecider = self::getMethod('createRetryDecider', new RetryMiddlewareFactory());
+        $generalDecider = $createRetryDecider->invokeArgs(
+            null,
+            array(RetryMiddlewareFactory::GENERAL_RETRY_TYPE, 3, false, true)
+        );
+        $request = new Request('PUT', '127.0.0.1');
+        $retryResult = $generalDecider(1, $request, new Response(403));
         $this->assertTrue($retryResult);
     }
 


### PR DESCRIPTION
Hi!

I'd like to add middleware retries when authentication fails.

We've seen some auth failures (for example in RequestId: fa6420bf-b002-0132-0ae1-e526ec000000) when using Table Storage but that seemed to be an isolated incident – just one failure without any code deployment or server config change.

I'd like to combat these 403 errors with automated retries. Currently, the middleware doesn't retry on 403 errors and that's what this PR adds.

Auth retries need to be optionally enabled (just like connection retries introduced in #148).

I've also add the retry middleware documentation to the README.

Let me know if you'd like me to do any changes or so.

Thanks!