### PR TITLE
Add client-request-id to requests

### DIFF
--- a/azure-storage-common/src/Common/Internal/Middlewares/CommonRequestMiddleware.php
+++ b/azure-storage-common/src/Common/Internal/Middlewares/CommonRequestMiddleware.php
@@ -105,9 +105,9 @@ class CommonRequestMiddleware extends MiddlewareBase
         $date = gmdate(Resources::AZURE_DATE_FORMAT, time());
         $result = $result->withHeader(Resources::DATE, $date);
 
-        //Adding request-ID if not specified by the user.
-        if (!$result->hasHeader(Resources::X_MS_REQUEST_ID)) {
-            $result = $result->withHeader(Resources::X_MS_REQUEST_ID, \uniqid());
+        //Adding client request-ID if not specified by the user.
+        if (!$result->hasHeader(Resources::X_MS_CLIENT_REQUEST_ID)) {
+            $result = $result->withHeader(Resources::X_MS_CLIENT_REQUEST_ID, \uniqid());
         }
         //Sign the request if authentication scheme is not null.
         $request = $this->authenticationScheme == null ?

--- a/azure-storage-common/src/Common/Internal/Resources.php
+++ b/azure-storage-common/src/Common/Internal/Resources.php
@@ -158,6 +158,7 @@ class Resources
     const X_MS_CONTINUATION_NEXTPARTITIONKEY = 'x-ms-continuation-nextpartitionkey';
     const X_MS_CONTINUATION_NEXTROWKEY       = 'x-ms-continuation-nextrowkey';
     const X_MS_REQUEST_ID                    = 'x-ms-request-id';
+    const X_MS_CLIENT_REQUEST_ID             = 'x-ms-client-request-id';
     const X_MS_CONTINUATION_LOCATION_MODE    = 'x-ms-continuation-location-mode';
     const X_MS_TYPE                          = 'x-ms-type';
     const X_MS_CONTENT_LENGTH                = 'x-ms-content-length';


### PR DESCRIPTION
According to the [docs](https://docs.microsoft.com/en-gb/rest/api/storageservices/storage-analytics-log-format), `x-ms-request-id` is added by the server ("The request ID assigned by the storage service.") and it's ignored when sent by the client.

Although the comment says the user can specify the header too, that's not actually correct at the moment but that's being dealt with in #222.

Fix #231

Thanks!