### PR TITLE
Update getContinuationToken return type fixes #237

### DIFF
--- a/azure-storage-common/src/Common/MarkerContinuationTokenTrait.php
+++ b/azure-storage-common/src/Common/MarkerContinuationTokenTrait.php
@@ -63,7 +63,7 @@ trait MarkerContinuationTokenTrait
     /**
      * Getter for continuationToken
      *
-     * @return ContinuationToken
+     * @return MarkerContinuationToken
      */
     public function getContinuationToken()
     {


### PR DESCRIPTION
Change DocBlock return type `ContinuationToken` to be `MarkerContinuationToken`.