### PR TITLE
Lowercase some QP_ const based on Rest API docs

### DIFF
--- a/azure-storage-common/src/Common/Internal/Resources.php
+++ b/azure-storage-common/src/Common/Internal/Resources.php
@@ -246,10 +246,10 @@ class Resources
 
     // Query parameter names
     const QP_ENTRIES            = 'Entries';
-    const QP_PREFIX             = 'Prefix';
-    const QP_MAX_RESULTS        = 'MaxResults';
+    const QP_PREFIX             = 'prefix';
+    const QP_MAX_RESULTS        = 'maxresults';
     const QP_METADATA           = 'Metadata';
-    const QP_MARKER             = 'Marker';
+    const QP_MARKER             = 'marker';
     const QP_NEXT_MARKER        = 'NextMarker';
     const QP_COMP               = 'comp';
     const QP_INCLUDE            = 'include';


### PR DESCRIPTION
Lowercased `QP_PREFIX`, `QP_MAX_RESULTS`, and `QP_MARKER` values based on documentation from https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs#uri-parameters

Allows support for Azurite Azure/Azurite#465

Fixes #235