### PR TITLE
Document retry middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,46 @@ implements `MicrosoftAzure\Storage\Common\Internal\IMiddleware`, or a
 
 User can create self-defined middleware that inherits from `MicrosoftAzure\Storage\Common\Internal\Middlewares\MiddlewareBase`.
 
+### Retrying failures
+You can use bundled middlewares to retry requests in case they fail for some reason. First you create the middleware:
+```php
+$retryMiddleware = RetryMiddlewareFactory::create(
+    RetryMiddlewareFactory::GENERAL_RETRY_TYPE,  // Specifies the retry logic
+    3,  // Number of retries
+    1000,  // Interval
+    RetryMiddlewareFactory::EXPONENTIAL_INTERVAL_ACCUMULATION,  // How to increase the wait interval
+    true  // Whether to retry connection failures too, default false
+);
+```
+
+Then you add the middleware when creating the service as explained above:
+```php
+$optionsWithMiddlewares = [
+    'middlewares' = [
+        $retryMiddleware
+    ],
+];
+$tableClient = TableRestProxy::createTableService(
+    $connectionString,
+    $optionsWithMiddlewares
+);
+```
+
+Or by pushing it to the existing service:
+```php
+$tableClient->pushMiddleware($retryMiddleware);
+```
+
+Authentication failures and "not found" errors (HTTP codes 403 & 404) are not retried when using the bundled middleware.
+
+#### Retry types
+- `RetryMiddlewareFactory::GENERAL_RETRY_TYPE` - General type of logic that handles retry
+- `RetryMiddlewareFactory::APPEND_BLOB_RETRY_TYPE` - For the append blob retry only, currently the same as the general type
+
+#### Interval accumulations
+- `RetryMiddlewareFactory::LINEAR_INTERVAL_ACCUMULATION` - The interval will be increased linearly, the *nth* retry will have a wait time equal to *n * interval*
+- `RetryMiddlewareFactory::EXPONENTIAL_INTERVAL_ACCUMULATION` - The interval will be increased exponentially, the *nth* retry will have a wait time equal to *pow(2, n) * interval*
+
 ### Using proxies
 To use proxies during HTTP requests, set system variable `HTTP_PROXY` and the proxy will be used.
 

--- a/azure-storage-common/src/Common/Middlewares/RetryMiddlewareFactory.php
+++ b/azure-storage-common/src/Common/Middlewares/RetryMiddlewareFactory.php
@@ -193,7 +193,8 @@ class RetryMiddlewareFactory
     /**
      * Decide if the given status code indicate the request should be retried.
      *
-     * @param  int $statusCode status code of the previous request.
+     * @param  int  $statusCode  Status code of the previous request.
+     * @param  bool $isSecondary Whether the request is sent to secondary endpoint.
      *
      * @return bool            true if the request should be retried.
      */
@@ -216,11 +217,12 @@ class RetryMiddlewareFactory
      * Decide if the given status code indicate the request should be retried.
      * This is for append blob.
      *
-     * @param  int $statusCode status code of the previous request.
+     * @param  int  $statusCode  Status code of the previous request.
+     * @param  bool $isSecondary Whether the request is sent to secondary endpoint.
      *
      * @return bool            true if the request should be retried.
      */
-    protected static function appendBlobRetryDecider($statusCode)
+    protected static function appendBlobRetryDecider($statusCode, $isSecondary)
     {
         //The retry logic is different for append blob.
         //First it will need to record the former status code if it is
@@ -228,7 +230,7 @@ class RetryMiddlewareFactory
         //needs to be retried. Currently this is not implemented so will
         //only adapt to the general retry decider.
         //TODO: add logic for append blob's retry when implemented.
-        $retry = self::generalRetryDecider($statusCode);
+        $retry = self::generalRetryDecider($statusCode, $isSecondary);
         return $retry;
     }
 


### PR DESCRIPTION
Adds `RetryMiddleware` docs, fixes `appendBlobRetryDecider()` params.

Extracted from #223.

Thanks!