### PR TITLE
Convert to exception when promise is rejected with string

### DIFF
--- a/azure-storage-common/src/Common/Internal/ServiceRestProxy.php
+++ b/azure-storage-common/src/Common/Internal/ServiceRestProxy.php
@@ -402,22 +402,33 @@ class ServiceRestProxy extends RestProxy
                 );
             },
             function ($reason) use ($expected) {
-                if (!($reason instanceof RequestException)) {
-                    throw $reason;
-                }
-                $response = $reason->getResponse();
-                if ($response != null) {
-                    self::throwIfError(
-                        $response,
-                        $expected
-                    );
-                } else {
-                    //if could not get response but promise rejected, throw reason.
-                    throw $reason;
-                }
-                return $response;
+                return $this->onRejected($reason, $expected);
             }
         );
+    }
+
+    /**
+     * @param  string|\Exception $reason   Rejection reason.
+     * @param  array|int         $expected Expected Status Codes.
+     *
+     * @return ResponseInterface
+     */
+    protected function onRejected($reason, $expected)
+    {
+        if (!($reason instanceof RequestException)) {
+            throw $reason;
+        }
+        $response = $reason->getResponse();
+        if ($response != null) {
+            self::throwIfError(
+                $response,
+                $expected
+            );
+        } else {
+            //if could not get response but promise rejected, throw reason.
+            throw $reason;
+        }
+        return $response;
     }
 
     /**

--- a/azure-storage-common/src/Common/Internal/ServiceRestProxy.php
+++ b/azure-storage-common/src/Common/Internal/ServiceRestProxy.php
@@ -415,6 +415,9 @@ class ServiceRestProxy extends RestProxy
      */
     protected function onRejected($reason, $expected)
     {
+        if (!($reason instanceof \Exception)) {
+            throw new \RuntimeException($reason);
+        }
         if (!($reason instanceof RequestException)) {
             throw $reason;
         }

--- a/tests/Unit/Common/Internal/ServiceRestProxyTest.php
+++ b/tests/Unit/Common/Internal/ServiceRestProxyTest.php
@@ -229,6 +229,20 @@ class ServiceRestProxyTest extends ReflectionTestBase
     /**
      * @depends testConstruct
      */
+    public function testOnRejectedWithString($proxy)
+    {
+        // Setup
+        $message = 'test message';
+        $this->setExpectedException(\RuntimeException::class, $message);
+        $onRejected = self::getMethod('onRejected', $proxy);
+
+        // Test
+        $onRejected->invokeArgs($proxy, array($message, 200));
+    }
+
+    /**
+     * @depends testConstruct
+     */
     public function testOnRejectedWithRequestExceptionNullResponse($proxy)
     {
         // Setup


### PR DESCRIPTION
Hi,

this is an attempt at fixing "Error: Can only throw objects" returned in some very unusual and rare situations.

If the promise returned by `ServiceRestProxy` is rejected with a string instead of an exception, convert the string to a `RuntimeException` and throw it.

Let me know what do you think :-) Thanks!

Closes #259.