### PR TITLE
Fix random number range that might cause an overflow in the guid generation

### DIFF
--- a/azure-storage-common/src/Common/Internal/Utilities.php
+++ b/azure-storage-common/src/Common/Internal/Utilities.php
@@ -562,7 +562,7 @@ class Utilities
             mt_rand(0, 64) + 128,       // 8 bits  for "clock_seq_hi", with
                                         // the most significant 2 bits being 10,
                                         // required by version 4 GUIDs.
-            mt_rand(0, 256),            // 8 bits  for "clock_seq_low"
+            mt_rand(0, 255),            // 8 bits  for "clock_seq_low"
             mt_rand(0, 65535),          // 16 bits for "node 0" and "node 1"
             mt_rand(0, 65535),          // 16 bits for "node 2" and "node 3"
             mt_rand(0, 65535)           // 16 bits for "node 4" and "node 5"


### PR DESCRIPTION
This fixes rare cases where the random number would be 256 which means it will cause the formatting `%02x` to have 3 characters `100` instead of the expected two `ff`.