### PR TITLE
support php8 changes

### DIFF
--- a/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
+++ b/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
@@ -291,7 +291,7 @@ class SharedAccessSignatureHelper
         }
 
         Validate::isTrue(
-            strlen($input) == '',
+            strlen($input) == 0,
             sprintf(
                 Resources::STRING_NOT_WITH_GIVEN_COMBINATION,
                 implode(', ', $array)


### PR DESCRIPTION
Following PHP 8 RFC https://wiki.php.net/rfc/string_to_number_comparison, you can no longer compare `0 == ''` and expect a `true` result. 

This PR fixes the following snippet which suppose to generate a SAS url: 

```
$sas_helper = new MicrosoftAzure\Storage\Blob\BlobSharedAccessSignatureHelper(
    $accountName, $accountKey);
$sas = $sas_helper->generateBlobServiceSharedAccessSignatureToken(
    MicrosoftAzure\Storage\Blob\Internal\BlobResources::RESOURCE_TYPE_BLOB,              # Resource name to generate the canonicalized resource. It can be Resources::RESOURCE_TYPE_BLOB or Resources::RESOURCE_TYPE_CONTAINER
    "{$containerName}/{$blobName}",                     # The name of the resource, including the path of the resource. It should be {container}/{blob}: for blobs.
    "r",                                        # Signed permissions.
    (new \DateTime())->modify('+10 minute'),    # Signed expiry
    (new \DateTime())->modify('-5 minute'),     # Signed start
    '',                                         # Signed IP, the range of IP addresses from which a request will be accepted, eg. "168.1.5.60-168.1.5.70"
    'https',                                    # Signed protocol, should always be https
);
echo "https://{$accountName}.blob.core.windows.net/{$containerName}/{$blobName}?{$sas}";
```

