### PR TITLE
Use String type for partition and row keys, always

### DIFF
--- a/azure-storage-table/src/Table/Internal/JsonODataReaderWriter.php
+++ b/azure-storage-table/src/Table/Internal/JsonODataReaderWriter.php
@@ -202,6 +202,8 @@ class JsonODataReaderWriter implements IODataReaderWriter
             $edmType;
             if (array_key_exists($key . Resources::JSON_ODATA_TYPE_SUFFIX, $rawEntity)) {
                 $edmType = $rawEntity[$key . Resources::JSON_ODATA_TYPE_SUFFIX];
+            } elseif (in_array($key, [Resources::JSON_PARTITION_KEY, Resources::JSON_ROW_KEY], true)) {
+                $edmType = EdmType::STRING;
             } else {
                 // Guess the property type
                 $edmType = EdmType::propertyType($value);

--- a/tests/Unit/Table/Internal/JsonODataReaderWriterTest.php
+++ b/tests/Unit/Table/Internal/JsonODataReaderWriterTest.php
@@ -135,6 +135,28 @@ class JsonODataReaderWriterTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+
+    public function testParseEntityStringKeys()
+    {
+        // Setup
+        $serializer = new JsonODataReaderWriter();
+        $expected = TestResources::getExpectedTestEntity('0e123', '123e456');
+        $json = TestResources::getEntityMinimalMetaResult('0e123', '123e456');
+
+        // Test
+        $actual = $serializer->parseEntity($json);
+
+        // Assert
+        $this->assertSame(
+            $expected->getPartitionKey(),
+            $actual->getPartitionKey()
+        );
+        $this->assertSame(
+            $expected->getRowKey(),
+            $actual->getRowKey()
+        );
+    }
+
     public function testParseEntities()
     {
         // Setup


### PR DESCRIPTION
Always use `EdmType::STRING` for PartitionKey and RowKey entities that don't have a type specified in the JSON and can only be strings.

Fix #277