### PR TITLE
#295 Add missing x-ms-blob-type header to createFile and createFileFromContents requests

### DIFF
--- a/azure-storage-common/src/Common/Internal/Resources.php
+++ b/azure-storage-common/src/Common/Internal/Resources.php
@@ -161,6 +161,7 @@ class Resources
     const X_MS_CLIENT_REQUEST_ID             = 'x-ms-client-request-id';
     const X_MS_CONTINUATION_LOCATION_MODE    = 'x-ms-continuation-location-mode';
     const X_MS_TYPE                          = 'x-ms-type';
+    const X_MS_BLOB_TYPE                     = 'x-ms-blob-type';
     const X_MS_CONTENT_LENGTH                = 'x-ms-content-length';
     const X_MS_CACHE_CONTROL                 = 'x-ms-cache-control';
     const X_MS_CONTENT_TYPE                  = 'x-ms-content-type';

--- a/azure-storage-file/src/File/FileRestProxy.php
+++ b/azure-storage-file/src/File/FileRestProxy.php
@@ -349,11 +349,9 @@ class FileRestProxy extends ServiceRestProxy implements IFile
         }
 
         $this->addOptionalHeader(
-          $headers,
-          Resources::X_MS_BLOB_TYPE,
-          'BlockBlob'
+            $headers,
+            Resources::X_MS_BLOB_TYPE, 'BlockBlob'
         );
-
 
         $this->addOptionalQueryParam(
             $queryParams,

--- a/azure-storage-file/src/File/FileRestProxy.php
+++ b/azure-storage-file/src/File/FileRestProxy.php
@@ -350,7 +350,8 @@ class FileRestProxy extends ServiceRestProxy implements IFile
 
         $this->addOptionalHeader(
             $headers,
-            Resources::X_MS_BLOB_TYPE, 'BlockBlob'
+            Resources::X_MS_BLOB_TYPE,
+            'BlockBlob'
         );
 
         $this->addOptionalQueryParam(
@@ -1598,9 +1599,9 @@ class FileRestProxy extends ServiceRestProxy implements IFile
         );
 
         $this->addOptionalHeader(
-          $headers,
-          Resources::X_MS_BLOB_TYPE,
-          'BlockBlob'
+            $headers,
+            Resources::X_MS_BLOB_TYPE,
+            'BlockBlob'
         );
 
         $this->addOptionalQueryParam(
@@ -2245,9 +2246,9 @@ class FileRestProxy extends ServiceRestProxy implements IFile
         );
 
         $this->addOptionalHeader(
-          $headers,
-          Resources::X_MS_BLOB_TYPE,
-          'BlockBlob'
+            $headers,
+            Resources::X_MS_BLOB_TYPE,
+            'BlockBlob'
         );
 
         $this->addOptionalHeader(

--- a/azure-storage-file/src/File/FileRestProxy.php
+++ b/azure-storage-file/src/File/FileRestProxy.php
@@ -348,11 +348,12 @@ class FileRestProxy extends ServiceRestProxy implements IFile
             $options = new PutFileRangeOptions();
         }
 
-        $this->addOptionalQueryParam(
-            $queryParams,
-            Resources::QP_COMP,
-            'range'
+        $this->addOptionalHeader(
+          $headers,
+          Resources::X_MS_BLOB_TYPE,
+          'BlockBlob'
         );
+
 
         $this->addOptionalQueryParam(
             $queryParams,
@@ -398,11 +399,6 @@ class FileRestProxy extends ServiceRestProxy implements IFile
             $chunkRange = new Range($start);
             $chunkRange->setLength($size);
 
-            $selfInstance->addOptionalHeader(
-                $headers,
-                Resources::X_MS_RANGE,
-                $chunkRange->getRangeString()
-            );
 
             $this->addOptionalHeader(
                 $headers,
@@ -1603,6 +1599,12 @@ class FileRestProxy extends ServiceRestProxy implements IFile
             'file'
         );
 
+        $this->addOptionalHeader(
+          $headers,
+          Resources::X_MS_BLOB_TYPE,
+          'BlockBlob'
+        );
+
         $this->addOptionalQueryParam(
             $queryParams,
             Resources::QP_TIMEOUT,
@@ -2245,9 +2247,9 @@ class FileRestProxy extends ServiceRestProxy implements IFile
         );
 
         $this->addOptionalHeader(
-            $headers,
-            Resources::X_MS_RANGE,
-            $range->getRangeString()
+          $headers,
+          Resources::X_MS_BLOB_TYPE,
+          'BlockBlob'
         );
 
         $this->addOptionalHeader(
@@ -2266,12 +2268,6 @@ class FileRestProxy extends ServiceRestProxy implements IFile
             $headers,
             Resources::CONTENT_MD5,
             $options->getContentMD5()
-        );
-
-        $this->addOptionalQueryParam(
-            $queryParams,
-            Resources::QP_COMP,
-            'range'
         );
 
         return $this->sendAsync(


### PR DESCRIPTION
This PR closes #295 to the best of my knowledge.

I've removed headers that make the request fail, these could be required and the configuration could be missing elsewhere but this was the success I had testing and fixing this with limited knowledge of the blob storage api.

I've also added the additional and seemingly missing `x-ms-blob-type` header. The value is fixed to `BlockBlob` as this felt most appropriate for this operation based on https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction#blobs