### PR TITLE
allow guzzle 7.3, alter query calls to use Psr7\Query object

### DIFF
--- a/azure-storage-blob/src/Blob/BlobRestProxy.php
+++ b/azure-storage-blob/src/Blob/BlobRestProxy.php
@@ -89,6 +89,7 @@ use MicrosoftAzure\Storage\Common\LocationMode;
 use MicrosoftAzure\Storage\Common\Models\Range;
 use MicrosoftAzure\Storage\Common\SharedAccessSignatureHelper;
 use Psr\Http\Message\StreamInterface;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * This class constructs HTTP requests and receive HTTP responses for blob
@@ -759,7 +760,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
                 get_class(new Range(0))
             )
         );
-        $body = Psr7\stream_for($content);
+        $body = Utils::streamFor($content);
 
         $method      = Resources::HTTP_PUT;
         $headers     = array();
@@ -1834,7 +1835,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $content,
         Models\CreateBlockBlobOptions $options = null
     ) {
-        $body = Psr7\stream_for($content);
+        $body = Utils::streamFor($content);
 
         //If the size of the stream is not seekable or larger than the single
         //upload threshold then call concurrent upload. Otherwise call putBlob.
@@ -1915,7 +1916,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $content,
         Models\CreatePageBlobFromContentOptions $options = null
     ) {
-        $body = Psr7\stream_for($content);
+        $body = Utils::streamFor($content);
         $self = $this;
 
         if (is_null($options)) {
@@ -2417,7 +2418,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $content,
         Models\CreateBlobPagesOptions $options = null
     ) {
-        $contentStream = Psr7\stream_for($content);
+        $contentStream = Utils::streamFor($content);
         //because the content is at most 4MB long, can retrieve all the data
         //here at once.
         $body = $contentStream->getContents();
@@ -2516,7 +2517,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $postParams     = array();
         $queryParams    = $this->createBlobBlockQueryParams($options, $blockId);
         $path           = $this->createPath($container, $blob);
-        $contentStream  = Psr7\stream_for($content);
+        $contentStream  = Utils::streamFor($content);
         $body           = $contentStream->getContents();
 
         $options->setLocationMode(LocationMode::PRIMARY_ONLY);
@@ -2597,7 +2598,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
         $queryParams    = array();
         $path           = $this->createPath($container, $blob);
 
-        $contentStream  = Psr7\stream_for($content);
+        $contentStream  = Utils::streamFor($content);
         $length         = $contentStream->getSize();
         $body           = $contentStream->getContents();
 
@@ -3791,7 +3792,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
             );
         });
     }
-    
+
     /**
      * Undeletes a blob.
      *
@@ -3810,7 +3811,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
     ) {
         $this->undeleteBlobAsync($container, $blob, $options)->wait();
     }
-    
+
     /**
      * Undeletes a blob.
      *

--- a/azure-storage-common/src/Common/Internal/Authentication/SharedKeyAuthScheme.php
+++ b/azure-storage-common/src/Common/Internal/Authentication/SharedKeyAuthScheme.php
@@ -24,6 +24,7 @@
 
 namespace MicrosoftAzure\Storage\Common\Internal\Authentication;
 
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
 use MicrosoftAzure\Storage\Common\Internal\Http\HttpFormatter;
 use MicrosoftAzure\Storage\Common\Internal\Resources;
@@ -305,7 +306,7 @@ class SharedKeyAuthScheme implements IAuthScheme
         $signedKey = $this->getAuthorizationHeader(
             $requestHeaders,
             $request->getUri(),
-            \GuzzleHttp\Psr7\parse_query(
+            Query::parse(
                 $request->getUri()->getQuery()
             ),
             $request->getMethod()

--- a/azure-storage-common/src/Common/Internal/ServiceRestProxy.php
+++ b/azure-storage-common/src/Common/Internal/ServiceRestProxy.php
@@ -297,7 +297,7 @@ class ServiceRestProxy extends RestProxy
 
         // add query parameters into headers
         if ($queryParams != null) {
-            $queryString = Psr7\build_query($queryParams);
+            $queryString = Psr7\Query::build($queryParams);
             $uri = $uri->withQuery($queryString);
         }
 
@@ -306,7 +306,7 @@ class ServiceRestProxy extends RestProxy
         if (empty($body)) {
             if (empty($headers[Resources::CONTENT_TYPE])) {
                 $headers[Resources::CONTENT_TYPE] = Resources::URL_ENCODED_CONTENT_TYPE;
-                $actualBody = Psr7\build_query($postParameters);
+                $actualBody = Psr7\Query::build($postParameters);
             }
         } else {
             $actualBody = $body;

--- a/azure-storage-common/src/Common/Internal/Validate.php
+++ b/azure-storage-common/src/Common/Internal/Validate.php
@@ -312,6 +312,9 @@ class Validate
     {
         $isValid = filter_var($uri, FILTER_VALIDATE_URL);
 
+//        debug_print_backtrace();
+//        throw new \Exception($uri);
+
         if ($isValid) {
             return true;
         } else {

--- a/azure-storage-common/src/Common/Internal/Validate.php
+++ b/azure-storage-common/src/Common/Internal/Validate.php
@@ -312,9 +312,6 @@ class Validate
     {
         $isValid = filter_var($uri, FILTER_VALIDATE_URL);
 
-//        debug_print_backtrace();
-//        throw new \Exception($uri);
-
         if ($isValid) {
             return true;
         } else {

--- a/azure-storage-file/src/File/FileRestProxy.php
+++ b/azure-storage-file/src/File/FileRestProxy.php
@@ -2226,7 +2226,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
         Validate::notNullOrEmpty($path, 'path');
         Validate::notNullOrEmpty($share, 'share');
         Validate::notNull($range->getLength(), Resources::RESOURCE_RANGE_LENGTH_MUST_SET);
-        $stream = Psr7\stream_for($content);
+        $stream = Psr7\Utils::streamFor($content);
 
         $method      = Resources::HTTP_PUT;
         $headers     = array();
@@ -2323,7 +2323,7 @@ class FileRestProxy extends ServiceRestProxy implements IFile
         $content,
         CreateFileFromContentOptions $options = null
     ) {
-        $stream = Psr7\stream_for($content);
+        $stream = Psr7\Utils::streamFor($content);
         $size = $stream->getSize();
 
         if ($options == null) {

--- a/tests/Unit/Blob/Models/GetBlobResultTest.php
+++ b/tests/Unit/Blob/Models/GetBlobResultTest.php
@@ -54,7 +54,7 @@ class GetBlobResultTest extends \PHPUnit\Framework\TestCase
         // Test
         $actual = GetBlobResult::create(
             $expected,
-            Psr7\stream_for($expectedBody),
+            Psr7\Utils::streamFor($expectedBody),
             $expectedMetadata
         );
 

--- a/tests/Unit/Common/Internal/UtilitiesTest.php
+++ b/tests/Unit/Common/Internal/UtilitiesTest.php
@@ -590,7 +590,7 @@ class UtilitiesTest extends \PHPUnit\Framework\TestCase
             fwrite($resource, openssl_random_pseudo_bytes(4194304));
         }
         rewind($resource);
-        $stream = Psr7\Utils::streamForam_for($resource);
+        $stream = Psr7\Utils::streamFor($resource);
         $result_0 = Utilities::isStreamLargerThanSizeOrNotSeekable(
             $stream,
             4194304 * 16 - 1

--- a/tests/Unit/Common/Internal/UtilitiesTest.php
+++ b/tests/Unit/Common/Internal/UtilitiesTest.php
@@ -590,7 +590,7 @@ class UtilitiesTest extends \PHPUnit\Framework\TestCase
             fwrite($resource, openssl_random_pseudo_bytes(4194304));
         }
         rewind($resource);
-        $stream = Psr7\stream_for($resource);
+        $stream = Psr7\Utils::streamForam_for($resource);
         $result_0 = Utilities::isStreamLargerThanSizeOrNotSeekable(
             $stream,
             4194304 * 16 - 1
@@ -602,7 +602,7 @@ class UtilitiesTest extends \PHPUnit\Framework\TestCase
         //prepare a string
         $count = 64 / 4;
         $testStr = openssl_random_pseudo_bytes(4194304 * $count);
-        $stream = Psr7\stream_for($testStr);
+        $stream = Psr7\Utils::streamFor($testStr);
         $result_2 = Utilities::isStreamLargerThanSizeOrNotSeekable(
             $stream,
             4194304 * 16 - 1


### PR DESCRIPTION
I have removed all calls to old methods; I have found so far. I do use it on our production servers with no issues. After last commit also the SAS authentication works.