### PR TITLE
Fix type hint for ServiceException::getResponse()

### DIFF
--- a/azure-storage-common/src/Common/Exceptions/ServiceException.php
+++ b/azure-storage-common/src/Common/Exceptions/ServiceException.php
@@ -168,7 +168,7 @@ class ServiceException extends \LogicException
     /**
      * Gets the response of the failue.
      *
-     * @return string
+     * @return ResponseInterface
      */
     public function getResponse()
     {


### PR DESCRIPTION
Returned type is actually `ResponseInterface` and not a `string`