### PR TITLE
Import Psr\Http\Message\StreamInterface

### DIFF
--- a/azure-storage-blob/src/Blob/Internal/IBlob.php
+++ b/azure-storage-blob/src/Blob/Internal/IBlob.php
@@ -28,6 +28,7 @@ use MicrosoftAzure\Storage\Blob\Models as BlobModels;
 use MicrosoftAzure\Storage\Common\Models\ServiceOptions;
 use MicrosoftAzure\Storage\Common\Models\ServiceProperties;
 use MicrosoftAzure\Storage\Common\Models\Range;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * This interface has all REST APIs provided by Windows Azure for Blob service.


### PR DESCRIPTION
The docblocks use `StreamInterface` as a type but the import was missing causing static analyzers to look for `MicrosoftAzure\Storage\Blob\Internal\StreamInterface` instead of `Psr\Http\Message\StreamInterface`.