### PR TITLE
Fix broken links in markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-If you intend to contribute to the project, please make sure you've followed the instructions provided in the [Azure Projects Contribution Guidelines](http://azure.github.io/guidelines/).
+If you intend to contribute to the project, please make sure you've followed the instructions provided in the [Azure Projects Contribution Guidelines](https://opensource.microsoft.com/program/#program-contributing).
 ## Project Setup
 The Azure Storage development team uses [Eclipse for PHP Developers](http://www.eclipse.org/downloads/packages/eclipse-php-developers/mars2) so instructions will be tailored to that preference. However, any preferred IDE or other toolset should be usable.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Be sure to check out the Microsoft Azure [Developer Forums on Stack Overflow](ht
 
 # Contribute Code or Provide Feedback
 
-If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](http://azure.github.io/guidelines/).
+If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](https://opensource.microsoft.com/program/#program-contributing).
 You can find more details for contributing in the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/Azure/azure-storage-php/issues) section of the project.

--- a/azure-storage-blob/README.md
+++ b/azure-storage-blob/README.md
@@ -153,7 +153,7 @@ cURL can't verify the validity of Microsoft certificate when trying to issue a r
 
 ## Code samples
 
-You can find samples in the [sample folder](samples)
+You can find samples in the [samples folder](https://github.com/Azure/azure-storage-php/tree/master/samples)
 
 
 # Migrate from [Azure SDK for PHP](https://github.com/Azure/azure-sdk-for-php/)
@@ -168,7 +168,7 @@ Be sure to check out the Microsoft Azure [Developer Forums on Stack Overflow](ht
 
 # Contribute Code or Provide Feedback
 
-If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](https://azure.github.io/guidelines/).
+If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](https://opensource.microsoft.com/program/#program-contributing).
 You can find more details for contributing in the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/Azure/azure-storage-php/issues) section of the project.

--- a/azure-storage-file/README.md
+++ b/azure-storage-file/README.md
@@ -163,7 +163,7 @@ Be sure to check out the Microsoft Azure [Developer Forums on Stack Overflow](ht
 
 # Contribute Code or Provide Feedback
 
-If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](http://azure.github.io/guidelines/).
+If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](https://opensource.microsoft.com/program/#program-contributing).
 You can find more details for contributing in the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/Azure/azure-storage-php/issues) section of the project.

--- a/azure-storage-queue/README.md
+++ b/azure-storage-queue/README.md
@@ -152,7 +152,7 @@ cURL can't verify the validity of Microsoft certificate when trying to issue a r
 
 ## Code samples
 
-You can find samples in the [sample folder](samples)
+You can find samples in the [samples folder](https://github.com/Azure/azure-storage-php/tree/master/samples)
 
 
 # Migrate from [Azure SDK for PHP](https://github.com/Azure/azure-sdk-for-php/)
@@ -167,7 +167,7 @@ Be sure to check out the Microsoft Azure [Developer Forums on Stack Overflow](ht
 
 # Contribute Code or Provide Feedback
 
-If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](http://azure.github.io/guidelines/).
+If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](https://opensource.microsoft.com/program/#program-contributing).
 You can find more details for contributing in the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/Azure/azure-storage-php/issues) section of the project.

--- a/azure-storage-table/README.md
+++ b/azure-storage-table/README.md
@@ -149,7 +149,7 @@ cURL can't verify the validity of Microsoft certificate when trying to issue a r
 
 ## Code samples
 
-You can find samples in the [sample folder](samples)
+You can find samples in the [samples folder](https://github.com/Azure/azure-storage-php/tree/master/samples)
 
 
 # Migrate from [Azure SDK for PHP](https://github.com/Azure/azure-sdk-for-php/)
@@ -164,7 +164,7 @@ Be sure to check out the Microsoft Azure [Developer Forums on Stack Overflow](ht
 
 # Contribute Code or Provide Feedback
 
-If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](http://azure.github.io/guidelines/).
+If you would like to become an active contributor to this project please follow the instructions provided in [Azure Projects Contribution Guidelines](https://opensource.microsoft.com/program/#program-contributing).
 You can find more details for contributing in the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 If you encounter any bugs with the library please file an issue in the [Issues](https://github.com/Azure/azure-storage-php/issues) section of the project.


### PR DESCRIPTION
Some of the sample links are broken.

As for Contribution Guidelines links, I took this [PR](https://github.com/Azure/azure-libraries-for-net/pull/1210) as reference.
