### PR TITLE
Check $copyProgress is not null before using it in strpos on PHP 8.1

### DIFF
--- a/azure-storage-blob/src/Blob/Models/CopyState.php
+++ b/azure-storage-blob/src/Blob/Models/CopyState.php
@@ -74,7 +74,7 @@ class CopyState
 
         $copyProgress = Utilities::tryGetValue($clean, 'copyprogress');
 
-        if (strpos($copyProgress, '/') !== false) {
+        if (!is_null($copyProgress) && strpos($copyProgress, '/') !== false) {
             $parts = explode('/', $copyProgress);
             $bytesCopied = intval($parts[0]);
             $totalBytes = intval($parts[1]);
@@ -112,7 +112,7 @@ class CopyState
         $result->setSource(Utilities::tryGetValue($clean, Resources::X_MS_COPY_SOURCE));
 
         $copyProgress = Utilities::tryGetValue($clean, Resources::X_MS_COPY_PROGRESS);
-        if (strpos($copyProgress, '/') !== false) {
+        if (!is_null($copyProgress) && strpos($copyProgress, '/') !== false) {
             $parts = explode('/', $copyProgress);
             $bytesCopied = intval($parts[0]);
             $totalBytes = intval($parts[1]);


### PR DESCRIPTION
Passing nulls to string params is deprecated in PHP 8.1.

Fix #320