### PR TITLE
Remove EOL from Content-Type header

### DIFF
--- a/azure-storage-table/src/Table/Internal/MimeReaderWriter.php
+++ b/azure-storage-table/src/Table/Internal/MimeReaderWriter.php
@@ -73,7 +73,7 @@ class MimeReaderWriter implements IMimeReaderWriter
         $batchBody         =& $result['body'];
         $batchHeaders      =& $result['headers'];
 
-        $batchHeaders['Content-Type'] = $mimeType . "; $eof boundary=\"$batchId\"";
+        $batchHeaders['Content-Type'] = $mimeType . "; boundary=\"$batchId\"";
 
         $batchBody .= "--" . $batchId . $eof;
         $batchBody .= "Content-Type: $mimeType; boundary=\"$changeSetId\"" . $eof;


### PR DESCRIPTION
Because new version of guzzlehttp/psr7 which fixes a security bug now fails on EOLs in header values.

Fix #327