### PR TITLE
Fix a warning of PHP 8.1 while listing blobs

### DIFF
--- a/azure-storage-blob/src/Blob/BlobRestProxy.php
+++ b/azure-storage-blob/src/Blob/BlobRestProxy.php
@@ -1521,11 +1521,13 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
             Resources::QP_COMP,
             'list'
         );
-        $this->addOptionalQueryParam(
-            $queryParams,
-            Resources::QP_PREFIX_LOWERCASE,
-            str_replace('\\', '/', $options->getPrefix())
-        );
+        if (null !== $options->getPrefix()) {
+            $this->addOptionalQueryParam(
+                $queryParams,
+                Resources::QP_PREFIX_LOWERCASE,
+                str_replace('\\', '/', $options->getPrefix())
+            );
+        }
         $this->addOptionalQueryParam(
             $queryParams,
             Resources::QP_MARKER_LOWERCASE,


### PR DESCRIPTION
`str_replace` with 3rd parameter null is deprecated (and makes no sense)

I tested this fix successfully, not specifying the parameter is 100% supported by azure.