### PR TITLE
Fix deprecation warning in PHP8.1

### DIFF
--- a/azure-storage-common/src/Common/Internal/Utilities.php
+++ b/azure-storage-common/src/Common/Internal/Utilities.php
@@ -603,6 +603,9 @@ class Utilities
      */
     public static function endsWith($haystack, $needle, $ignoreCase = false)
     {
+        if (null === $haystack) {
+            return '';
+        }
         if ($ignoreCase) {
             $haystack = strtolower($haystack);
             $needle   = strtolower($needle);


### PR DESCRIPTION
`src/Common/Internal/ServiceRestProxy.php:80` may call this function with null, the line `return (substr($haystack, -$length) === $needle);` is an issue because PHP 8.1 deprecated the use of `substr` on null.