### PR TITLE
Fix SAS URL

### DIFF
--- a/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
+++ b/azure-storage-common/src/Common/SharedAccessSignatureHelper.php
@@ -165,8 +165,8 @@ class SharedAccessSignatureHelper
         $sas .= '&ss=' . $signedService;
         $sas .= '&srt=' . $signedResourceType;
         $sas .= '&sp=' . $signedPermissions;
-        $sas .= '&se=' . $signedExpiry;
-        $sas .= $signedStart === ''? '' : '&st=' . $signedStart;
+        $sas .= '&se=' . urlencode($signedExpiry);
+        $sas .= $signedStart === ''? '' : '&st=' . urlencode($signedStart);
         $sas .= $signedIP === ''? '' : '&sip=' . $signedIP;
         $sas .= '&spr=' . $signedProtocol;
         $sas .= '&sig=' . $sig;


### PR DESCRIPTION
storage service returns fields, not well-formed error when trying to access file/ res from a link that is valid for mins