### PR TITLE
PHP 8.1 deprecation error: Make sure haystack is a string

### DIFF
--- a/azure-storage-common/src/Common/Internal/Utilities.php
+++ b/azure-storage-common/src/Common/Internal/Utilities.php
@@ -612,7 +612,7 @@ class Utilities
             return true;
         }
 
-        return (substr($haystack, -$length) === $needle);
+        return (substr((string) $haystack, -$length) === $needle);
     }
 
     /**


### PR DESCRIPTION
Fixes #347 
